### PR TITLE
feat(server): Notion API連携の実装 #3

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -19,19 +19,19 @@
   - .gitignoreに.envを追加
   - _Requirements: 4.4, 5.1, 8.2_
 
-- [ ] 2. Notion API連携の実装
-  - [ ] 2.1 NotionClientクラスの実装
+- [x] 2. Notion API連携の実装
+  - [x] 2.1 NotionClientクラスの実装
     - 環境変数から認証情報を読み込むコンストラクタ
     - queryByIsbn()メソッド: ISBNでデータベース検索
     - createBookRecord()メソッド: 新規ページ作成
     - エラーハンドリングとレート制限対応
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
-  
-  - [ ] 2.2 NotionClientのプロパティテスト
+
+  - [x] 2.2 NotionClientのプロパティテスト
     - **Property 14: Book_RecordからNotionプロパティへのマッピング**
     - **Validates: Requirements 5.2, 5.3**
-  
-  - [ ] 2.3 NotionClientのユニットテスト
+
+  - [x] 2.3 NotionClientのユニットテスト
     - 環境変数読込のテスト
     - Notion APIエラー処理のテスト（モック使用）
     - レート制限処理のテスト

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "pnpm -r typecheck",
     "typecheck:f": "bash -c 'pnpm --filter $1 typecheck' _",
     "test:f": "bash -c 'pnpm --filter $1 test' _",
+    "test:coverage:f": "bash -c 'pnpm --filter $1 exec vitest run --coverage' _",
     "build": "pnpm -r build",
     "build:f": "bash -c 'pnpm --filter $1 build' _",
     "dev:f": "bash -c 'pnpm --filter $1 dev' _",
@@ -23,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@vitest/coverage-v8": "3.2.4",
     "eslint": "^9.20.0",
     "fast-check": "^3.23.0",
     "prettier": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "prettier": "^3.5.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.24.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/server/src/services/notion-client.ts
+++ b/packages/server/src/services/notion-client.ts
@@ -1,0 +1,187 @@
+import { Client, APIErrorCode, isNotionClientError } from "@notionhq/client";
+import type { BookData } from "@techbook-ledger/shared";
+
+export interface NotionPage {
+  readonly id: string;
+  readonly url: string;
+}
+
+interface NotionBookClientConfig {
+  readonly token: string;
+  readonly databaseId: string;
+  readonly retryDelayMs?: number;
+}
+
+const MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 400;
+
+export class NotionAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotionAuthError";
+  }
+}
+
+export class NotionRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotionRateLimitError";
+  }
+}
+
+export class NotionConnectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotionConnectionError";
+  }
+}
+
+export function buildNotionProperties(
+  bookData: BookData,
+  registrationDate: Date,
+): Record<string, unknown> {
+  return {
+    ISBN: {
+      title: [{ text: { content: bookData.isbn } }],
+    },
+    タイトル: {
+      rich_text: [{ text: { content: bookData.title } }],
+    },
+    著者: {
+      rich_text: [{ text: { content: bookData.author } }],
+    },
+    出版社: {
+      rich_text: [{ text: { content: bookData.publisher } }],
+    },
+    価格: {
+      number: bookData.price,
+    },
+    発売日: {
+      date: { start: bookData.publicationDate },
+    },
+    ページ数: {
+      number: bookData.pageCount,
+    },
+    登録元URL: {
+      url: bookData.sourceUrl,
+    },
+    登録日時: {
+      date: { start: registrationDate.toISOString() },
+    },
+  };
+}
+
+function isRateLimitError(error: unknown): boolean {
+  return (
+    isNotionClientError(error) &&
+    "code" in error &&
+    error.code === APIErrorCode.RateLimited
+  );
+}
+
+function classifyAndThrow(error: unknown): never {
+  if (isNotionClientError(error) && "code" in error) {
+    const code = (error as { code: string }).code;
+
+    if (code === APIErrorCode.Unauthorized) {
+      throw new NotionAuthError(
+        "Notion認証に失敗しました。環境変数を確認してください",
+      );
+    }
+
+    if (code === APIErrorCode.RateLimited) {
+      throw new NotionRateLimitError(
+        "Notion APIがビジー状態です。しばらく待ってから再試行してください",
+      );
+    }
+
+    if (code === APIErrorCode.ServiceUnavailable) {
+      throw new NotionConnectionError(
+        "Notionに接続できません。ネットワーク接続を確認してください",
+      );
+    }
+  }
+
+  throw new NotionConnectionError(
+    "Notionに接続できません。ネットワーク接続を確認してください",
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class NotionBookClient {
+  private readonly client: Client;
+  private readonly databaseId: string;
+  private readonly retryDelayMs: number;
+
+  constructor(config: NotionBookClientConfig) {
+    this.client = new Client({ auth: config.token });
+    this.databaseId = config.databaseId;
+    this.retryDelayMs = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  }
+
+  async queryByIsbn(isbn: string): Promise<NotionPage | null> {
+    const normalizedIsbn = isbn.toLowerCase();
+
+    const response = await this.executeWithRetry(() =>
+      this.client.databases.query({
+        database_id: this.databaseId,
+        filter: {
+          property: "ISBN",
+          title: {
+            equals: normalizedIsbn,
+          },
+        },
+      }),
+    );
+
+    if (response.results.length === 0) {
+      return null;
+    }
+
+    const page = response.results[0] as { id: string; url: string };
+    return {
+      id: page.id,
+      url: page.url,
+    };
+  }
+
+  async createBookRecord(bookData: BookData): Promise<string> {
+    const registrationDate = new Date();
+    const properties = buildNotionProperties(bookData, registrationDate);
+
+    const response = await this.executeWithRetry(() =>
+      this.client.pages.create({
+        parent: { database_id: this.databaseId },
+        properties: properties as Parameters<
+          typeof this.client.pages.create
+        >[0]["properties"],
+      }),
+    );
+
+    return (response as { url: string }).url;
+  }
+
+  private async executeWithRetry<T>(operation: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await operation();
+      } catch (error: unknown) {
+        lastError = error;
+
+        if (!isRateLimitError(error) || attempt === MAX_RETRIES) {
+          break;
+        }
+
+        const waitMs = this.retryDelayMs * Math.pow(2, attempt);
+        await delay(waitMs);
+      }
+    }
+
+    classifyAndThrow(lastError);
+  }
+}

--- a/packages/server/src/services/notion-client.ts
+++ b/packages/server/src/services/notion-client.ts
@@ -36,13 +36,17 @@ export class NotionConnectionError extends Error {
   }
 }
 
+export function normalizeIsbn(isbn: string): string {
+  return isbn.trim().toLowerCase();
+}
+
 export function buildNotionProperties(
   bookData: BookData,
   registrationDate: Date,
 ): Record<string, unknown> {
   return {
     ISBN: {
-      title: [{ text: { content: bookData.isbn } }],
+      title: [{ text: { content: normalizeIsbn(bookData.isbn) } }],
     },
     タイトル: {
       rich_text: [{ text: { content: bookData.title } }],
@@ -95,6 +99,12 @@ function classifyAndThrow(error: unknown): never {
       );
     }
 
+    if (code === APIErrorCode.ObjectNotFound) {
+      throw new NotionConnectionError(
+        "指定されたNotionデータベースが見つかりません。データベースIDとインテグレーション権限を確認してください",
+      );
+    }
+
     if (code === APIErrorCode.ServiceUnavailable) {
       throw new NotionConnectionError(
         "Notionに接続できません。ネットワーク接続を確認してください",
@@ -123,7 +133,7 @@ export class NotionBookClient {
   }
 
   async queryByIsbn(isbn: string): Promise<NotionPage | null> {
-    const normalizedIsbn = isbn.toLowerCase();
+    const normalizedIsbn = normalizeIsbn(isbn);
 
     const response = await this.executeWithRetry(() =>
       this.client.databases.query({

--- a/packages/server/tests/property/notion-client.test.ts
+++ b/packages/server/tests/property/notion-client.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import type { BookData } from "@techbook-ledger/shared";
+import { buildNotionProperties } from "../../src/services/notion-client.js";
+
+// BookData arbitrary generator
+const bookDataArb: fc.Arbitrary<BookData> = fc.record({
+  isbn: fc.oneof(
+    fc.stringOf(fc.constantFrom("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), {
+      minLength: 10,
+      maxLength: 10,
+    }),
+    fc.stringOf(fc.constantFrom("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), {
+      minLength: 13,
+      maxLength: 13,
+    }),
+  ),
+  title: fc.string({ minLength: 1, maxLength: 200 }),
+  author: fc.string({ minLength: 1, maxLength: 100 }),
+  publisher: fc.string({ minLength: 1, maxLength: 100 }),
+  price: fc.integer({ min: 100, max: 50000 }),
+  publicationDate: fc
+    .date({
+      min: new Date("1990-01-01"),
+      max: new Date("2030-12-31"),
+    })
+    .map((d) => d.toISOString().split("T")[0]),
+  pageCount: fc.integer({ min: 1, max: 5000 }),
+  sourceUrl: fc.webUrl(),
+});
+
+const registrationDateArb: fc.Arbitrary<Date> = fc.date({
+  min: new Date("2020-01-01"),
+  max: new Date("2030-12-31"),
+});
+
+describe("Feature: tech-book-decision-support, Property 14: BookRecordからNotionプロパティへのマッピング", () => {
+  it("should map ISBN to Notion title property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const isbn = properties["ISBN"] as {
+          title: Array<{ text: { content: string } }>;
+        };
+
+        expect(isbn).toBeDefined();
+        expect(isbn.title).toHaveLength(1);
+        expect(isbn.title[0].text.content).toBe(bookData.isbn);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map title to Notion rich_text property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const title = properties["タイトル"] as {
+          rich_text: Array<{ text: { content: string } }>;
+        };
+
+        expect(title).toBeDefined();
+        expect(title.rich_text).toHaveLength(1);
+        expect(title.rich_text[0].text.content).toBe(bookData.title);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map author to Notion rich_text property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const author = properties["著者"] as {
+          rich_text: Array<{ text: { content: string } }>;
+        };
+
+        expect(author).toBeDefined();
+        expect(author.rich_text).toHaveLength(1);
+        expect(author.rich_text[0].text.content).toBe(bookData.author);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map publisher to Notion rich_text property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const publisher = properties["出版社"] as {
+          rich_text: Array<{ text: { content: string } }>;
+        };
+
+        expect(publisher).toBeDefined();
+        expect(publisher.rich_text).toHaveLength(1);
+        expect(publisher.rich_text[0].text.content).toBe(bookData.publisher);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map price to Notion number property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const price = properties["価格"] as { number: number };
+
+        expect(price).toBeDefined();
+        expect(price.number).toBe(bookData.price);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map publicationDate to Notion date property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const pubDate = properties["発売日"] as {
+          date: { start: string };
+        };
+
+        expect(pubDate).toBeDefined();
+        expect(pubDate.date.start).toBe(bookData.publicationDate);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map pageCount to Notion number property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const pageCount = properties["ページ数"] as { number: number };
+
+        expect(pageCount).toBeDefined();
+        expect(pageCount.number).toBe(bookData.pageCount);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should map sourceUrl to Notion url property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const sourceUrl = properties["登録元URL"] as { url: string };
+
+        expect(sourceUrl).toBeDefined();
+        expect(sourceUrl.url).toBe(bookData.sourceUrl);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should auto-assign registrationDate as Notion date property for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+        const regDateProp = properties["登録日時"] as {
+          date: { start: string };
+        };
+
+        expect(regDateProp).toBeDefined();
+        expect(regDateProp.date.start).toBe(regDate.toISOString());
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should produce exactly 9 properties for all valid BookData", () => {
+    fc.assert(
+      fc.property(bookDataArb, registrationDateArb, (bookData, regDate) => {
+        const properties = buildNotionProperties(bookData, regDate);
+
+        expect(Object.keys(properties)).toHaveLength(9);
+        expect(Object.keys(properties).sort()).toEqual(
+          [
+            "ISBN",
+            "タイトル",
+            "著者",
+            "出版社",
+            "価格",
+            "発売日",
+            "ページ数",
+            "登録元URL",
+            "登録日時",
+          ].sort(),
+        );
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/server/tests/property/notion-client.test.ts
+++ b/packages/server/tests/property/notion-client.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 import type { BookData } from "@techbook-ledger/shared";
-import { buildNotionProperties } from "../../src/services/notion-client.js";
+import {
+  buildNotionProperties,
+  normalizeIsbn,
+} from "../../src/services/notion-client.js";
 
 // BookData arbitrary generator
 const bookDataArb: fc.Arbitrary<BookData> = fc.record({
@@ -45,7 +48,7 @@ describe("Feature: tech-book-decision-support, Property 14: BookRecordからNoti
 
         expect(isbn).toBeDefined();
         expect(isbn.title).toHaveLength(1);
-        expect(isbn.title[0].text.content).toBe(bookData.isbn);
+        expect(isbn.title[0].text.content).toBe(normalizeIsbn(bookData.isbn));
       }),
       { numRuns: 100 },
     );

--- a/packages/server/tests/unit/notion-client.test.ts
+++ b/packages/server/tests/unit/notion-client.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BookData } from "@techbook-ledger/shared";
+
+// Mock @notionhq/client before importing NotionClient
+const mockDatabasesQuery = vi.fn();
+const mockPagesCreate = vi.fn();
+
+vi.mock("@notionhq/client", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    databases: { query: mockDatabasesQuery },
+    pages: { create: mockPagesCreate },
+  })),
+  APIErrorCode: {
+    Unauthorized: "unauthorized",
+    RateLimited: "rate_limited",
+    ServiceUnavailable: "service_unavailable",
+    ObjectNotFound: "object_not_found",
+  },
+  isNotionClientError: (error: unknown): boolean => {
+    return error instanceof Error && "code" in error;
+  },
+}));
+
+import {
+  NotionBookClient,
+  buildNotionProperties,
+  NotionAuthError,
+  NotionRateLimitError,
+  NotionConnectionError,
+} from "../../src/services/notion-client.js";
+
+function createBookData(overrides: Partial<BookData> = {}): BookData {
+  return {
+    isbn: "9784297138189",
+    title: "プロフェッショナルWebプログラミング TypeScript",
+    author: "山田太郎",
+    publisher: "技術評論社",
+    price: 3520,
+    publicationDate: "2024-03-15",
+    pageCount: 432,
+    sourceUrl: "https://gihyo.jp/book/2024/978-4-297-13818-9",
+    ...overrides,
+  };
+}
+
+function createNotionError(code: string, status: number): Error {
+  const error = new Error(`Notion API error: ${code}`);
+  Object.assign(error, { code, status });
+  return error;
+}
+
+describe("NotionBookClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create an instance with token and databaseId", () => {
+      const client = new NotionBookClient({
+        token: "secret_test_token",
+        databaseId: "test-database-id",
+      });
+      expect(client).toBeInstanceOf(NotionBookClient);
+    });
+  });
+
+  describe("queryByIsbn", () => {
+    it("should return NotionPage when a matching record exists", async () => {
+      const mockPage = {
+        id: "page-id-123",
+        url: "https://www.notion.so/page-id-123",
+      };
+      mockDatabasesQuery.mockResolvedValueOnce({
+        results: [mockPage],
+      });
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+      const result = await client.queryByIsbn("9784297138189");
+
+      expect(result).toEqual({
+        id: "page-id-123",
+        url: "https://www.notion.so/page-id-123",
+      });
+      expect(mockDatabasesQuery).toHaveBeenCalledWith({
+        database_id: "db-id",
+        filter: {
+          property: "ISBN",
+          title: {
+            equals: "9784297138189",
+          },
+        },
+      });
+    });
+
+    it("should return null when no matching record exists", async () => {
+      mockDatabasesQuery.mockResolvedValueOnce({
+        results: [],
+      });
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+      const result = await client.queryByIsbn("9784297138189");
+
+      expect(result).toBeNull();
+    });
+
+    it("should normalize ISBN to lowercase for case-insensitive search", async () => {
+      mockDatabasesQuery.mockResolvedValueOnce({
+        results: [],
+      });
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+      await client.queryByIsbn("978X123456X");
+
+      expect(mockDatabasesQuery).toHaveBeenCalledWith({
+        database_id: "db-id",
+        filter: {
+          property: "ISBN",
+          title: {
+            equals: "978x123456x",
+          },
+        },
+      });
+    });
+  });
+
+  describe("createBookRecord", () => {
+    it("should map BookData to Notion properties and create a page", async () => {
+      const bookData = createBookData();
+      const mockCreatedPage = {
+        id: "new-page-id",
+        url: "https://www.notion.so/new-page-id",
+      };
+      mockPagesCreate.mockResolvedValueOnce(mockCreatedPage);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+      const url = await client.createBookRecord(bookData);
+
+      expect(url).toBe("https://www.notion.so/new-page-id");
+      expect(mockPagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parent: { database_id: "db-id" },
+          properties: expect.objectContaining({
+            ISBN: {
+              title: [{ text: { content: "9784297138189" } }],
+            },
+            タイトル: {
+              rich_text: [
+                {
+                  text: {
+                    content:
+                      "プロフェッショナルWebプログラミング TypeScript",
+                  },
+                },
+              ],
+            },
+            著者: {
+              rich_text: [{ text: { content: "山田太郎" } }],
+            },
+            出版社: {
+              rich_text: [{ text: { content: "技術評論社" } }],
+            },
+            価格: {
+              number: 3520,
+            },
+            発売日: {
+              date: { start: "2024-03-15" },
+            },
+            ページ数: {
+              number: 432,
+            },
+            登録元URL: {
+              url: "https://gihyo.jp/book/2024/978-4-297-13818-9",
+            },
+          }),
+        }),
+      );
+    });
+
+    it("should auto-assign registrationDate when creating a record", async () => {
+      vi.useFakeTimers();
+      const bookData = createBookData();
+      const now = new Date("2026-02-28T12:00:00.000Z");
+      vi.setSystemTime(now);
+
+      mockPagesCreate.mockResolvedValueOnce({
+        id: "new-page-id",
+        url: "https://www.notion.so/new-page-id",
+      });
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+      await client.createBookRecord(bookData);
+
+      expect(mockPagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            登録日時: {
+              date: { start: "2026-02-28T12:00:00.000Z" },
+            },
+          }),
+        }),
+      );
+      vi.useRealTimers();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw NotionAuthError on unauthorized error", async () => {
+      const error = createNotionError("unauthorized", 401);
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "invalid_token",
+        databaseId: "db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        NotionAuthError,
+      );
+    });
+
+    it("should include user-friendly message in NotionAuthError", async () => {
+      const error = createNotionError("unauthorized", 401);
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "invalid_token",
+        databaseId: "db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        "Notion認証に失敗しました。環境変数を確認してください",
+      );
+    });
+
+    it("should throw NotionRateLimitError after max retries on rate limit", async () => {
+      const error = createNotionError("rate_limited", 429);
+      mockDatabasesQuery.mockRejectedValue(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+        retryDelayMs: 0,
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        NotionRateLimitError,
+      );
+      // Initial call + 3 retries = 4 calls total
+      expect(mockDatabasesQuery).toHaveBeenCalledTimes(4);
+    });
+
+    it("should include user-friendly message in NotionRateLimitError", async () => {
+      const error = createNotionError("rate_limited", 429);
+      mockDatabasesQuery.mockRejectedValue(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+        retryDelayMs: 0,
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        "Notion APIがビジー状態です。しばらく待ってから再試行してください",
+      );
+    });
+
+    it("should throw NotionConnectionError on network error", async () => {
+      const error = new Error("fetch failed");
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        NotionConnectionError,
+      );
+    });
+
+    it("should include user-friendly message in NotionConnectionError", async () => {
+      const error = new Error("fetch failed");
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        "Notionに接続できません。ネットワーク接続を確認してください",
+      );
+    });
+
+    it("should succeed after rate limit retry", async () => {
+      const rateLimitError = createNotionError("rate_limited", 429);
+      const mockPage = {
+        id: "page-id-123",
+        url: "https://www.notion.so/page-id-123",
+      };
+
+      mockDatabasesQuery
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({ results: [mockPage] });
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+        retryDelayMs: 0,
+      });
+
+      const result = await client.queryByIsbn("9784297138189");
+
+      expect(result).toEqual({
+        id: "page-id-123",
+        url: "https://www.notion.so/page-id-123",
+      });
+      expect(mockDatabasesQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw NotionConnectionError on service unavailable error", async () => {
+      const error = createNotionError("service_unavailable", 503);
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        NotionConnectionError,
+      );
+    });
+
+    it("should propagate errors from createBookRecord as well", async () => {
+      const error = createNotionError("unauthorized", 401);
+      mockPagesCreate.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "invalid_token",
+        databaseId: "db-id",
+      });
+
+      await expect(
+        client.createBookRecord(createBookData()),
+      ).rejects.toThrow(NotionAuthError);
+    });
+  });
+});
+
+describe("buildNotionProperties", () => {
+  it("should map all BookData fields to Notion property format", () => {
+    const bookData = createBookData();
+    const now = new Date("2026-02-28T12:00:00.000Z");
+
+    const properties = buildNotionProperties(bookData, now);
+
+    expect(properties).toEqual({
+      ISBN: {
+        title: [{ text: { content: "9784297138189" } }],
+      },
+      タイトル: {
+        rich_text: [
+          {
+            text: {
+              content:
+                "プロフェッショナルWebプログラミング TypeScript",
+            },
+          },
+        ],
+      },
+      著者: {
+        rich_text: [{ text: { content: "山田太郎" } }],
+      },
+      出版社: {
+        rich_text: [{ text: { content: "技術評論社" } }],
+      },
+      価格: {
+        number: 3520,
+      },
+      発売日: {
+        date: { start: "2024-03-15" },
+      },
+      ページ数: {
+        number: 432,
+      },
+      登録元URL: {
+        url: "https://gihyo.jp/book/2024/978-4-297-13818-9",
+      },
+      登録日時: {
+        date: { start: "2026-02-28T12:00:00.000Z" },
+      },
+    });
+  });
+});

--- a/packages/server/tests/unit/notion-client.test.ts
+++ b/packages/server/tests/unit/notion-client.test.ts
@@ -190,31 +190,34 @@ describe("NotionBookClient", () => {
 
     it("should auto-assign registrationDate when creating a record", async () => {
       vi.useFakeTimers();
-      const bookData = createBookData();
-      const now = new Date("2026-02-28T12:00:00.000Z");
-      vi.setSystemTime(now);
+      try {
+        const bookData = createBookData();
+        const now = new Date("2026-02-28T12:00:00.000Z");
+        vi.setSystemTime(now);
 
-      mockPagesCreate.mockResolvedValueOnce({
-        id: "new-page-id",
-        url: "https://www.notion.so/new-page-id",
-      });
+        mockPagesCreate.mockResolvedValueOnce({
+          id: "new-page-id",
+          url: "https://www.notion.so/new-page-id",
+        });
 
-      const client = new NotionBookClient({
-        token: "secret_test",
-        databaseId: "db-id",
-      });
-      await client.createBookRecord(bookData);
+        const client = new NotionBookClient({
+          token: "secret_test",
+          databaseId: "db-id",
+        });
+        await client.createBookRecord(bookData);
 
-      expect(mockPagesCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          properties: expect.objectContaining({
-            登録日時: {
-              date: { start: "2026-02-28T12:00:00.000Z" },
-            },
+        expect(mockPagesCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              登録日時: {
+                date: { start: "2026-02-28T12:00:00.000Z" },
+              },
+            }),
           }),
-        }),
-      );
-      vi.useRealTimers();
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -331,6 +334,34 @@ describe("NotionBookClient", () => {
         url: "https://www.notion.so/page-id-123",
       });
       expect(mockDatabasesQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw NotionConnectionError on object not found error", async () => {
+      const error = createNotionError("object_not_found", 404);
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "invalid-db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        NotionConnectionError,
+      );
+    });
+
+    it("should include user-friendly message in ObjectNotFound error", async () => {
+      const error = createNotionError("object_not_found", 404);
+      mockDatabasesQuery.mockRejectedValueOnce(error);
+
+      const client = new NotionBookClient({
+        token: "secret_test",
+        databaseId: "invalid-db-id",
+      });
+
+      await expect(client.queryByIsbn("9784297138189")).rejects.toThrow(
+        "指定されたNotionデータベースが見つかりません。データベースIDとインテグレーション権限を確認してください",
+      );
     });
 
     it("should throw NotionConnectionError on service unavailable error", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.39.3
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@25.3.2)(tsx@4.21.0))
       eslint:
         specifier: ^9.20.0
         version: 9.39.3
@@ -61,6 +64,31 @@ importers:
   packages/shared: {}
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -272,12 +300,34 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@notionhq/client@2.3.0':
     resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
     engines: {node: '>=12'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -517,6 +567,15 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -563,9 +622,21 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -576,6 +647,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -593,6 +667,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.3:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
@@ -711,8 +788,17 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -851,6 +937,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -886,6 +976,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -909,6 +1004,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -945,12 +1043,38 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -985,8 +1109,18 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1022,6 +1156,14 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -1074,6 +1216,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1089,6 +1234,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -1204,6 +1353,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1218,6 +1371,22 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1228,6 +1397,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1400,11 +1573,39 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -1541,7 +1742,30 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@notionhq/client@2.3.0':
     dependencies:
@@ -1549,6 +1773,9 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1786,6 +2013,25 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.3.2)(tsx@4.21.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@25.3.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1846,15 +2092,27 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
 
@@ -1883,6 +2141,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.3:
     dependencies:
@@ -1978,7 +2240,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -2186,6 +2454,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -2229,6 +2502,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   gopd@1.2.0: {}
@@ -2244,6 +2526,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2274,11 +2558,42 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -2309,9 +2624,21 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -2336,6 +2663,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
 
   ms@2.0.0: {}
 
@@ -2376,6 +2709,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2385,6 +2720,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -2534,6 +2874,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -2541,6 +2883,26 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
 
@@ -2551,6 +2913,12 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.4
 
   tinybench@2.9.0: {}
 
@@ -2708,5 +3076,17 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   yocto-queue@0.1.0: {}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -50,3 +50,24 @@
 - GitHub の `Closes #N` キーワードはデフォルトブランチ（main）へのマージ時のみ発動する
 - `develop` へのマージでは Issue は自動クローズされない
 - Git Flow 運用では `develop` → `main` マージ時に自動クローズされるのを待つ
+
+## Task 2: Notion API連携の実装
+
+### pnpm スクリプト経由でサブコマンドにフラグを渡す場合は `pnpm exec` を使う
+- `pnpm --filter $1 test -- --coverage` だと `vitest run "--" "--coverage"` になり `--` が二重化する
+- pnpm がスクリプト実行時に引数の前に自動で `--` を挿入するため
+- **解決策**: `pnpm --filter $1 exec vitest run --coverage` でツールを直接実行する
+- `pnpm exec` はパッケージの node_modules/.bin を PATH に追加して直接コマンドを実行する
+
+```json
+"test:coverage:f": "bash -c 'pnpm --filter $1 exec vitest run --coverage' _"
+```
+
+### @vitest/coverage-v8 のバージョンは vitest と揃える
+- `@vitest/coverage-v8` と `vitest` は同じバージョンにしないと peer dependency 警告が出る
+- vitest 3.2.4 なら `@vitest/coverage-v8@3.2.4` を指定する
+
+### vi.useFakeTimers() と async リトライの相互作用に注意
+- `vi.useFakeTimers()` はグローバルに全テストに影響する
+- `setTimeout` を使うリトライロジックがある場合、fake timers だとタイマーが自動で進まずタイムアウトする
+- **解決策**: fake timers はタイムスタンプ検証テストのみで使い、リトライテストでは `retryDelayMs: 0` を注入して real timers で実行する

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,3 +18,20 @@
 - サーバー起動: OK (http://127.0.0.1:3000 でリッスン確認)
 - .env が .gitignore に含まれている: OK
 - shared の型が server から import 可能: OK
+
+---
+
+# Task 2: Notion API連携の実装
+
+## Plan
+- [x] 2.3 NotionClient ユニットテストを先行作成（RED）
+- [x] 2.1 NotionClient クラスの実装（GREEN）
+- [x] 2.2 Property 14 プロパティテストの作成
+- [x] リファクタリングと品質確認（REFACTOR）
+
+## Review
+- lint: 0 errors, 0 warnings
+- type-check: Success (shared, server)
+- テスト: 26 passed (unit 16, property 10)
+- カバレッジ: notion-client.ts 100%/100%/100%/100%, 全体 85%+
+- ビルド: Build successful


### PR DESCRIPTION
## 概要

NotionBookClient クラスを TDD で実装し、Notion API との通信を可能にした。

## 背景・目的

Task 2 として、ローカルサーバーから Notion Database への読み書き機能が必要。
ISBN による重複検索と新規レコード作成を担う NotionClient を実装した。

Closes #3

## 変更内容

- `packages/server/src/services/notion-client.ts` を新規作成
  - `NotionBookClient` クラス: queryByIsbn(), createBookRecord()
  - `buildNotionProperties()` 純粋関数: BookData -> Notion プロパティマッピング
  - エラークラス: NotionAuthError, NotionRateLimitError, NotionConnectionError
  - 指数バックオフによるレート制限リトライ（最大3回）
- ユニットテスト 16 件 (`tests/unit/notion-client.test.ts`)
- プロパティテスト 10 件 (`tests/property/notion-client.test.ts`, Property 14)
- `@vitest/coverage-v8` を追加、`test:coverage:f` スクリプトを追加

## スコープ外（やっていないこと）

- Express ルートへの組み込み（Task 5 で実施）
- 重複チェッカー（Task 3 で実施）
- リクエストバリデーション（Task 4 で実施）

## 動作確認方法

1. `pnpm install`
2. `pnpm run test:f server` で全テスト実行 (26 passed)
3. `pnpm run test:coverage:f server` でカバレッジ確認 (notion-client.ts: 100%)
4. `pnpm run typecheck:f server` で型チェック
5. `pnpm lint` で lint チェック

## チェックリスト
- [x] セルフレビュー済み
- [x] テストを追加・更新した
- [x] 既存テストがすべて通る
- [x] ドキュメントを更新した（tasks.md, lessons.md）
- [ ] Breaking Changeがある場合は明記した (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Notion database integration for managing book records with resilient error handling and retry behavior.

* **Tests**
  * Added coverage-focused test script and tooling.
  * New comprehensive unit and property tests for Notion integration, covering mappings, retries, and error scenarios.

* **Documentation / Chores**
  * Updated task docs and checklists with Notion integration guidance, testing notes, and completed task statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->