### PR TITLE
feat(server): 重複チェックロジックの実装 #7

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,11 @@
       "Bash(pnpm build:*)",
       "Bash(pnpm run build:hooks-rs:*)",
       "Bash(cargo test:*)",
-      "Bash(jj squash:*)"
+      "Bash(jj squash:*)",
+      "Bash(pnpm run test:file:*)",
+      "Bash(jj split --help:*)",
+      "Bash(jj split:*)",
+      "Bash(jj abandon:*)"
     ]
   },
   "hooks": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ pnpm workspace による 3 パッケージ構成:
 
 `@techbook-ledger/shared` は server/extension から `workspace:*` で参照される。共通 devDeps (vitest, typescript, eslint 等) はルートに配置。
 
+詳細は [ai/rules/PROJECT_ARCHITECTURE.md](ai/rules/PROJECT_ARCHITECTURE.md) を参照。
+
 ## アーキテクチャ上の注意点
 
 - Notion API トークンはサーバー側の `.env` にのみ保存。ブラウザには一切露出しない
@@ -68,6 +70,8 @@ pnpm workspace による 3 パッケージ構成:
 - `vitest.config.ts` で `globals: true` (import 不要)
 - カバレッジ閾値 80% (server パッケージで設定済み)
 - Property tests は `docs/design.md` の Correctness Properties (Property 1-20) に対応
+
+詳細は [ai/rules/TESTING_STRATEGY.md](ai/rules/TESTING_STRATEGY.md) を参照。
 
 ## バージョン管理 (Jujutsu)
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -37,26 +37,26 @@
     - レート制限処理のテスト
     - _Requirements: 5.1, 5.4, 5.5_
 
-- [ ] 3. 重複チェックロジックの実装
-  - [ ] 3.1 Duplicate Checkerの実装
+- [x] 3. 重複チェックロジックの実装
+  - [x] 3.1 Duplicate Checkerの実装
     - checkDuplicate()関数: ISBN正規化と検索
     - 大文字小文字を区別しない比較
     - 既存レコードのURL取得
     - _Requirements: 6.1, 6.2, 6.3_
-  
-  - [ ] 3.2 重複チェックのプロパティテスト
+
+  - [x] 3.2 重複チェックのプロパティテスト
     - **Property 8: 重複チェックの実行**
     - **Validates: Requirements 3.2**
-  
-  - [ ] 3.3 重複チェックのプロパティテスト
+
+  - [x] 3.3 重複チェックのプロパティテスト
     - **Property 9: 重複時の登録拒否**
     - **Validates: Requirements 3.3**
-  
-  - [ ] 3.4 重複チェックのプロパティテスト
+
+  - [x] 3.4 重複チェックのプロパティテスト
     - **Property 16: ISBN大文字小文字の同一視**
     - **Validates: Requirements 6.2**
-  
-  - [ ] 3.5 重複チェックのプロパティテスト
+
+  - [x] 3.5 重複チェックのプロパティテスト
     - **Property 17: 重複検出時のURL返却**
     - **Validates: Requirements 6.3**
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "pnpm -r typecheck",
     "typecheck:f": "bash -c 'pnpm --filter $1 typecheck' _",
     "test:f": "bash -c 'pnpm --filter $1 test' _",
+    "test:file": "bash -c 'pnpm --filter $1 exec vitest run $2' _",
     "test:coverage:f": "bash -c 'pnpm --filter $1 exec vitest run --coverage' _",
     "build": "pnpm -r build",
     "build:f": "bash -c 'pnpm --filter $1 build' _",

--- a/packages/server/src/services/duplicate-checker.ts
+++ b/packages/server/src/services/duplicate-checker.ts
@@ -1,0 +1,23 @@
+import type { DuplicateCheckResult } from "@techbook-ledger/shared";
+import type { NotionPage } from "./notion-client.js";
+
+export interface IsbnQueryable {
+  queryByIsbn(isbn: string): Promise<NotionPage | null>;
+}
+
+export async function checkDuplicate(
+  isbn: string,
+  queryClient: IsbnQueryable,
+): Promise<DuplicateCheckResult> {
+  const page = await queryClient.queryByIsbn(isbn);
+
+  if (page === null) {
+    return { exists: false };
+  }
+
+  return {
+    exists: true,
+    notionPageId: page.id,
+    notionUrl: page.url,
+  };
+}

--- a/packages/server/tests/property/duplicate-checker.test.ts
+++ b/packages/server/tests/property/duplicate-checker.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import type { NotionPage } from "../../src/services/notion-client.js";
+import { normalizeIsbn } from "../../src/services/notion-client.js";
+import type { IsbnQueryable } from "../../src/services/duplicate-checker.js";
+import { checkDuplicate } from "../../src/services/duplicate-checker.js";
+
+// ISBN arbitrary generators (reuse pattern from notion-client property tests)
+const isbnDigitsArb = fc.oneof(
+  fc.stringOf(
+    fc.constantFrom("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
+    { minLength: 10, maxLength: 10 },
+  ),
+  fc.stringOf(
+    fc.constantFrom("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
+    { minLength: 13, maxLength: 13 },
+  ),
+);
+
+// ISBN with possible mixed case (for ISBN-10 check digit X)
+const isbnWithCaseArb = fc
+  .tuple(
+    fc.stringOf(
+      fc.constantFrom("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
+      { minLength: 9, maxLength: 9 },
+    ),
+    fc.constantFrom("X", "x", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"),
+  )
+  .map(([digits, last]) => digits + last);
+
+// Notion page arbitrary generator
+const notionPageArb: fc.Arbitrary<NotionPage> = fc
+  .tuple(
+    fc.uuid(),
+    fc.uuid(),
+  )
+  .map(([id, urlId]) => ({
+    id,
+    url: `https://www.notion.so/${urlId}`,
+  }));
+
+// Stub client that always finds a duplicate
+function createFoundClient(page: NotionPage): IsbnQueryable {
+  return {
+    queryByIsbn: async () => page,
+  };
+}
+
+// Stub client that never finds a duplicate
+function createNotFoundClient(): IsbnQueryable {
+  return {
+    queryByIsbn: async () => null,
+  };
+}
+
+// Spy client that records which ISBN was passed to queryByIsbn
+function createSpyClient(result: NotionPage | null): {
+  client: IsbnQueryable;
+  calledWith: string[];
+} {
+  const calledWith: string[] = [];
+  return {
+    client: {
+      queryByIsbn: async (isbn: string) => {
+        calledWith.push(isbn);
+        return result;
+      },
+    },
+    calledWith,
+  };
+}
+
+describe("Feature: tech-book-decision-support, Property 8: 重複チェックの実行", () => {
+  it("should execute ISBN search query for all received ISBNs", async () => {
+    await fc.assert(
+      fc.asyncProperty(isbnDigitsArb, async (isbn) => {
+        const spy = createSpyClient(null);
+
+        await checkDuplicate(isbn, spy.client);
+
+        expect(spy.calledWith).toHaveLength(1);
+        expect(spy.calledWith[0]).toBe(isbn);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+describe("Feature: tech-book-decision-support, Property 9: 重複時の登録拒否", () => {
+  it("should return exists: true and not create new record when ISBN already exists", async () => {
+    await fc.assert(
+      fc.asyncProperty(isbnDigitsArb, notionPageArb, async (isbn, existingPage) => {
+        const client = createFoundClient(existingPage);
+
+        const result = await checkDuplicate(isbn, client);
+
+        expect(result.exists).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should return exists: false when ISBN does not exist", async () => {
+    await fc.assert(
+      fc.asyncProperty(isbnDigitsArb, async (isbn) => {
+        const client = createNotFoundClient();
+
+        const result = await checkDuplicate(isbn, client);
+
+        expect(result.exists).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+describe("Feature: tech-book-decision-support, Property 16: ISBN大文字小文字の同一視", () => {
+  it("should produce identical normalized ISBN regardless of case", () => {
+    fc.assert(
+      fc.property(isbnWithCaseArb, (isbn) => {
+        const upperIsbn = isbn.toUpperCase();
+        const lowerIsbn = isbn.toLowerCase();
+
+        expect(normalizeIsbn(upperIsbn)).toBe(normalizeIsbn(lowerIsbn));
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should detect duplicate regardless of ISBN case", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        isbnWithCaseArb,
+        notionPageArb,
+        async (isbn, existingPage) => {
+          const upperIsbn = isbn.toUpperCase();
+          const lowerIsbn = isbn.toLowerCase();
+
+          // Simulate a client that normalizes internally (like NotionBookClient)
+          const normalizedIsbnValue = normalizeIsbn(isbn);
+          const normalizingClient: IsbnQueryable = {
+            queryByIsbn: async (queriedIsbn: string) => {
+              const normalized = normalizeIsbn(queriedIsbn);
+              if (normalized === normalizedIsbnValue) {
+                return existingPage;
+              }
+              return null;
+            },
+          };
+
+          const upperResult = await checkDuplicate(upperIsbn, normalizingClient);
+          const lowerResult = await checkDuplicate(lowerIsbn, normalizingClient);
+
+          expect(upperResult.exists).toBe(lowerResult.exists);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+describe("Feature: tech-book-decision-support, Property 17: 重複検出時のURL返却", () => {
+  it("should return existing Notion URL when duplicate is detected", async () => {
+    await fc.assert(
+      fc.asyncProperty(isbnDigitsArb, notionPageArb, async (isbn, existingPage) => {
+        const client = createFoundClient(existingPage);
+
+        const result = await checkDuplicate(isbn, client);
+
+        expect(result.exists).toBe(true);
+        expect(result.notionUrl).toBe(existingPage.url);
+        expect(result.notionPageId).toBe(existingPage.id);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should not include URL when no duplicate is found", async () => {
+    await fc.assert(
+      fc.asyncProperty(isbnDigitsArb, async (isbn) => {
+        const client = createNotFoundClient();
+
+        const result = await checkDuplicate(isbn, client);
+
+        expect(result.exists).toBe(false);
+        expect(result.notionUrl).toBeUndefined();
+        expect(result.notionPageId).toBeUndefined();
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/server/tests/unit/duplicate-checker.test.ts
+++ b/packages/server/tests/unit/duplicate-checker.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import type { NotionPage } from "../../src/services/notion-client.js";
+import type { IsbnQueryable } from "../../src/services/duplicate-checker.js";
+import { checkDuplicate } from "../../src/services/duplicate-checker.js";
+
+function createStubClient(
+  result: NotionPage | null,
+): IsbnQueryable & { queryByIsbn: ReturnType<typeof vi.fn> } {
+  return {
+    queryByIsbn: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("checkDuplicate", () => {
+  it("should return exists: false when no matching record found", async () => {
+    const client = createStubClient(null);
+
+    const result = await checkDuplicate("9784297138189", client);
+
+    expect(result.exists).toBe(false);
+    expect(result.notionPageId).toBeUndefined();
+    expect(result.notionUrl).toBeUndefined();
+  });
+
+  it("should return exists: true with pageId and url when matching record found", async () => {
+    const client = createStubClient({
+      id: "page-id-123",
+      url: "https://www.notion.so/page-id-123",
+    });
+
+    const result = await checkDuplicate("9784297138189", client);
+
+    expect(result.exists).toBe(true);
+    expect(result.notionPageId).toBe("page-id-123");
+    expect(result.notionUrl).toBe("https://www.notion.so/page-id-123");
+  });
+
+  it("should always call queryByIsbn to execute the search", async () => {
+    const client = createStubClient(null);
+
+    await checkDuplicate("9784297138189", client);
+
+    expect(client.queryByIsbn).toHaveBeenCalledTimes(1);
+    expect(client.queryByIsbn).toHaveBeenCalledWith("9784297138189");
+  });
+
+  it("should pass the isbn directly to queryByIsbn for normalization", async () => {
+    const client = createStubClient(null);
+
+    await checkDuplicate("978X123456X", client);
+
+    expect(client.queryByIsbn).toHaveBeenCalledWith("978X123456X");
+  });
+
+  it("should treat uppercase and lowercase ISBN as the same via queryByIsbn normalization", async () => {
+    const upperClient = createStubClient({
+      id: "page-upper",
+      url: "https://www.notion.so/page-upper",
+    });
+    const lowerClient = createStubClient({
+      id: "page-lower",
+      url: "https://www.notion.so/page-lower",
+    });
+
+    await checkDuplicate("978X123456X", upperClient);
+    await checkDuplicate("978x123456x", lowerClient);
+
+    // Both should call queryByIsbn - normalization happens inside queryByIsbn
+    expect(upperClient.queryByIsbn).toHaveBeenCalledTimes(1);
+    expect(lowerClient.queryByIsbn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should propagate errors from queryByIsbn", async () => {
+    const client = {
+      queryByIsbn: vi.fn().mockRejectedValue(new Error("Connection failed")),
+    };
+
+    await expect(checkDuplicate("9784297138189", client)).rejects.toThrow(
+      "Connection failed",
+    );
+  });
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -90,3 +90,15 @@
 - リモートに存在しない新規 bookmark を push すると「Refusing to create new remote bookmark」エラーになる
 - これは jj の安全機構で、意図しないリモート bookmark 作成を防ぐ設計
 - **回避策**: 初回 push 時は `jj git push --bookmark <name> --allow-new` を使う
+
+## Task 3: 重複チェックロジックの実装
+
+### fast-check で async コールバックには fc.asyncProperty を使う
+- `fc.property` に async コールバックを渡すと、Promise が truthy 値として扱われ「Property failed by returning false」エラーになる
+- **解決策**: `fc.asyncProperty` + `await fc.assert()` を使う
+- sync テストには `fc.property`、async テストには `fc.asyncProperty` と使い分ける
+
+### shared パッケージの tsbuildinfo が陳腐化すると dist が生成されない
+- `tsconfig.tsbuildinfo` が残っているが `dist/` が削除されている場合、`tsc` は「変更なし」と判断して何も出力しない
+- server の typecheck が `Cannot find module '@techbook-ledger/shared'` で失敗する
+- **回避策**: `tsconfig.tsbuildinfo` を削除してから `pnpm run build:f shared` を実行する

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -35,3 +35,23 @@
 - テスト: 26 passed (unit 16, property 10)
 - カバレッジ: notion-client.ts 100%/100%/100%/100%, 全体 85%+
 - ビルド: Build successful
+
+---
+
+# Task 3: 重複チェックロジックの実装
+
+## Plan
+- [x] 3.1 ユニットテスト作成 (tests/unit/duplicate-checker.test.ts) - RED
+- [x] 3.1 checkDuplicate() 実装 (src/services/duplicate-checker.ts) - GREEN
+- [x] 3.2 Property 8: 重複チェックの実行
+- [x] 3.3 Property 9: 重複時の登録拒否
+- [x] 3.4 Property 16: ISBN大文字小文字の同一視
+- [x] 3.5 Property 17: 重複検出時のURL返却
+- [x] 品質確認 (test, typecheck, lint, coverage)
+
+## Review
+- lint: 0 errors, 0 warnings
+- type-check: Success (shared, server)
+- テスト: 41 passed (unit 24, property 17)
+- カバレッジ: duplicate-checker.ts 100%/100%/100%/100%, services 全体 100%
+- 全体カバレッジ: 87%+ (閾値 80% クリア)


### PR DESCRIPTION
## 概要

ISBN をユニークキーとした重複チェックロジックを `DuplicateChecker` モジュールとして実装。

## 背景・目的

書籍登録時に同一 ISBN の重複登録を防止する仕組みが必要。
`NotionBookClient.queryByIsbn()` を活用し、ISBN 検索 → 重複判定 → 結果返却のフローを実現する。

Closes #7

## 変更内容

- `checkDuplicate()` 関数と `IsbnQueryable` インターフェースを新規作成
- ユニットテスト 6 件（正常系・異常系・エラー伝播）
- プロパティテスト 7 件（Properties 8, 9, 16, 17 をカバー）
- `test:file` スクリプトを追加（個別テストファイル実行用）
- CLAUDE.md にモノレポ構造・テストセクションの詳細リンクを追加

## スコープ外（やっていないこと）

- Express API エンドポイントへの統合（Task 5 で実施）
- リクエストバリデーション（Task 4 で実施）

## 動作確認方法

1. `pnpm install`
2. `pnpm run test:f server` で全 41 テストがパスすることを確認
3. `pnpm run test:coverage:f server` でカバレッジ 80%+ を確認
4. `pnpm run typecheck:f server` で型チェックがパスすることを確認

## チェックリスト

- [x] セルフレビュー済み
- [x] テストを追加・更新した
- [x] 既存テストがすべて通る
- [x] ドキュメントを更新した（必要な場合）
- [ ] Breaking Change がある場合は明記した

## レビュアーへのメモ

- `IsbnQueryable` インターフェースにより `NotionBookClient` との疎結合を実現。テスト時はスタブ注入で `@notionhq/client` のモック不要
- `normalizeIsbn()` は既存の `notion-client.ts` から再利用。ISBN の大文字小文字正規化は `queryByIsbn` 内部で実施される設計
- プロパティテストでは `fc.asyncProperty` を使用（async コールバック対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duplicate detection to identify existing ISBN entries.

* **Tests**
  * Added comprehensive unit and property tests covering duplicate detection, normalization, and error cases; introduced a test-for-file script.

* **Documentation**
  * Added cross-references to architecture/testing guides; added and completed duplicate-check task docs, lessons, and TODO items with testing guidance.

* **Chores**
  * Expanded allowed development/test command patterns for local workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->