### PR TITLE
feat(server): ISBN単位ロックで重複チェックをアトミック化

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -97,7 +97,7 @@
     - 各種エラーケースのレスポンス検証
     - _Requirements: 4.2, 4.6, 7.3_
 
-  - [ ] 5.6 重複チェックのアトミック化
+  - [x] 5.6 重複チェックのアトミック化
     - checkDuplicate → createBookRecord の非アトミック問題を解消
     - 同一ISBNの並行リクエストで二重登録が発生しうる
     - BookService に registerIfAbsent() 的なアトミック操作を導入検討

--- a/packages/server/src/routes/books.ts
+++ b/packages/server/src/routes/books.ts
@@ -1,24 +1,24 @@
 import { Router, type Request, type Response } from "express";
-import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
-import type { NotionPage } from "../services/notion-client.js";
+import type {
+  BookData,
+  RegisterResult,
+  RegistrationResponse,
+} from "@techbook-ledger/shared";
 import {
   NotionAuthError,
   NotionRateLimitError,
   NotionConnectionError,
 } from "../services/notion-client.js";
 import { validateBookRecord } from "../middleware/validator.js";
-import { checkDuplicate } from "../services/duplicate-checker.js";
 
 export interface BookService {
-  queryByIsbn(isbn: string): Promise<NotionPage | null>;
-  createBookRecord(bookData: BookData): Promise<string>;
+  registerIfAbsent(bookData: BookData): Promise<RegisterResult>;
 }
 
 export function createBooksRouter(bookService: BookService): Router {
   const router = Router();
 
   router.post("/", async (req: Request, res: Response) => {
-    // 1. Validate request
     const validation = validateBookRecord(req.body);
     if (!validation.valid) {
       const response: RegistrationResponse = {
@@ -32,31 +32,33 @@ export function createBooksRouter(bookService: BookService): Router {
     const bookData: BookData = req.body;
 
     try {
-      // 2. Check duplicate
-      const duplicateResult = await checkDuplicate(bookData.isbn, bookService);
-      if (duplicateResult.exists) {
+      const result = await bookService.registerIfAbsent(bookData);
+
+      if (result.created) {
+        const response: RegistrationResponse = {
+          success: true,
+          message: "書籍を登録しました",
+          notionUrl: result.notionUrl,
+        };
+        res.status(201).json(response);
+      } else {
         const response: RegistrationResponse = {
           success: false,
           message: "この書籍は既に登録されています",
-          notionUrl: duplicateResult.notionUrl,
+          notionUrl: result.notionUrl,
           isDuplicate: true,
         };
         res.status(200).json(response);
-        return;
       }
-
-      // 3. Create record in Notion
-      const notionUrl = await bookService.createBookRecord(bookData);
-      const response: RegistrationResponse = {
-        success: true,
-        message: "書籍を登録しました",
-        notionUrl,
-      };
-      res.status(201).json(response);
     } catch (error: unknown) {
-      const errorName = error instanceof Error ? error.constructor.name : "UnknownError";
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error("POST /api/books error:", { errorName, message: errorMessage });
+      const errorName =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("POST /api/books error:", {
+        errorName,
+        message: errorMessage,
+      });
 
       if (error instanceof NotionAuthError) {
         res.status(500).json({

--- a/packages/server/src/services/notion-client.ts
+++ b/packages/server/src/services/notion-client.ts
@@ -1,5 +1,6 @@
 import { Client, APIErrorCode, isNotionClientError } from "@notionhq/client";
-import type { BookData } from "@techbook-ledger/shared";
+import type { BookData, RegisterResult } from "@techbook-ledger/shared";
+import { withIsbnLock } from "../utils/isbn-lock.js";
 
 export interface NotionPage {
   readonly id: string;
@@ -172,6 +173,17 @@ export class NotionBookClient {
     );
 
     return (response as { url: string }).url;
+  }
+
+  async registerIfAbsent(bookData: BookData): Promise<RegisterResult> {
+    return withIsbnLock(bookData.isbn, async () => {
+      const existing = await this.queryByIsbn(bookData.isbn);
+      if (existing) {
+        return { created: false as const, notionUrl: existing.url };
+      }
+      const notionUrl = await this.createBookRecord(bookData);
+      return { created: true as const, notionUrl };
+    });
   }
 
   private async executeWithRetry<T>(operation: () => Promise<T>): Promise<T> {

--- a/packages/server/src/utils/isbn-lock.ts
+++ b/packages/server/src/utils/isbn-lock.ts
@@ -1,0 +1,25 @@
+const locks = new Map<string, Promise<void>>();
+
+export async function withIsbnLock<T>(
+  isbn: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = isbn.toLowerCase();
+
+  while (locks.has(key)) {
+    await locks.get(key);
+  }
+
+  let resolve: () => void;
+  const lock = new Promise<void>((r) => {
+    resolve = r;
+  });
+  locks.set(key, lock);
+
+  try {
+    return await fn();
+  } finally {
+    locks.delete(key);
+    resolve!();
+  }
+}

--- a/packages/server/tests/property/books-route.test.ts
+++ b/packages/server/tests/property/books-route.test.ts
@@ -47,14 +47,11 @@ describe("Feature: tech-book-decision-support, Property 10: 新規レコード�
     vi.clearAllMocks();
   });
 
-  it("should create a new record in Notion for all BookData with non-existing ISBN", async () => {
+  it("should return 201 for all BookData when registerIfAbsent returns created: true", async () => {
     await fc.assert(
       fc.asyncProperty(bookDataArb, notionUrlArb, async (bookData, notionUrl) => {
-        const createBookRecord = vi.fn().mockResolvedValue(notionUrl);
-        const mockService: BookService = {
-          queryByIsbn: vi.fn().mockResolvedValue(null),
-          createBookRecord,
-        };
+        const registerIfAbsent = vi.fn().mockResolvedValue({ created: true, notionUrl });
+        const mockService: BookService = { registerIfAbsent };
         const app = createTestApp(mockService);
 
         const response = await request(app)
@@ -64,24 +61,18 @@ describe("Feature: tech-book-decision-support, Property 10: 新規レコード�
         expect(response.status).toBe(201);
         expect(response.body.success).toBe(true);
         expect(response.body.notionUrl).toBe(notionUrl);
-        expect(createBookRecord).toHaveBeenCalledTimes(1);
-        expect(createBookRecord).toHaveBeenCalledWith(bookData);
+        expect(registerIfAbsent).toHaveBeenCalledTimes(1);
+        expect(registerIfAbsent).toHaveBeenCalledWith(bookData);
       }),
       { numRuns: 100 },
     );
   });
 
-  it("should not create a record when ISBN already exists", async () => {
+  it("should return 200 with isDuplicate when registerIfAbsent returns created: false", async () => {
     await fc.assert(
       fc.asyncProperty(bookDataArb, notionUrlArb, async (bookData, existingUrl) => {
-        const createBookRecord = vi.fn();
-        const mockService: BookService = {
-          queryByIsbn: vi.fn().mockResolvedValue({
-            id: "existing-id",
-            url: existingUrl,
-          }),
-          createBookRecord,
-        };
+        const registerIfAbsent = vi.fn().mockResolvedValue({ created: false, notionUrl: existingUrl });
+        const mockService: BookService = { registerIfAbsent };
         const app = createTestApp(mockService);
 
         const response = await request(app)
@@ -90,7 +81,7 @@ describe("Feature: tech-book-decision-support, Property 10: 新規レコード�
 
         expect(response.status).toBe(200);
         expect(response.body.isDuplicate).toBe(true);
-        expect(createBookRecord).not.toHaveBeenCalled();
+        expect(response.body.notionUrl).toBe(existingUrl);
       }),
       { numRuns: 100 },
     );
@@ -102,15 +93,14 @@ describe("Feature: tech-book-decision-support, Property 11: タイムスタン�
     vi.clearAllMocks();
   });
 
-  it("should pass BookData to createBookRecord which auto-assigns timestamp", async () => {
+  it("should pass BookData to registerIfAbsent which auto-assigns timestamp internally", async () => {
     await fc.assert(
       fc.asyncProperty(bookDataArb, async (bookData) => {
         let capturedBookData: BookData | undefined;
         const mockService: BookService = {
-          queryByIsbn: vi.fn().mockResolvedValue(null),
-          createBookRecord: vi.fn().mockImplementation(async (data: BookData) => {
+          registerIfAbsent: vi.fn().mockImplementation(async (data: BookData) => {
             capturedBookData = data;
-            return "https://www.notion.so/new-page";
+            return { created: true, notionUrl: "https://www.notion.so/new-page" };
           }),
         };
         const app = createTestApp(mockService);
@@ -122,8 +112,6 @@ describe("Feature: tech-book-decision-support, Property 11: タイムスタン�
         expect(response.status).toBe(201);
         expect(capturedBookData).toBeDefined();
         expect(capturedBookData).toEqual(bookData);
-        // The BookData passed to createBookRecord should NOT contain registrationDate
-        // (the server/NotionBookClient is responsible for adding timestamp internally)
         expect(capturedBookData).not.toHaveProperty("registrationDate");
       }),
       { numRuns: 100 },
@@ -141,10 +129,9 @@ describe("Feature: tech-book-decision-support, Property 13: 認証情報の非�
     await fc.assert(
       fc.asyncProperty(bookDataArb, async (bookData) => {
         const mockService: BookService = {
-          queryByIsbn: vi.fn().mockResolvedValue(null),
-          createBookRecord: vi
+          registerIfAbsent: vi
             .fn()
-            .mockResolvedValue("https://www.notion.so/new-page"),
+            .mockResolvedValue({ created: true, notionUrl: "https://www.notion.so/new-page" }),
         };
         const app = createTestApp(mockService);
 
@@ -170,11 +157,10 @@ describe("Feature: tech-book-decision-support, Property 13: 認証情報の非�
     await fc.assert(
       fc.asyncProperty(bookDataArb, async (bookData) => {
         const mockService: BookService = {
-          queryByIsbn: vi.fn().mockResolvedValue({
-            id: "page-id",
-            url: "https://www.notion.so/page-id",
+          registerIfAbsent: vi.fn().mockResolvedValue({
+            created: false,
+            notionUrl: "https://www.notion.so/page-id",
           }),
-          createBookRecord: vi.fn(),
         };
         const app = createTestApp(mockService);
 
@@ -205,8 +191,7 @@ describe("Feature: tech-book-decision-support, Property 13: 認証情報の非�
 
     for (const error of errorTypes) {
       const mockService: BookService = {
-        queryByIsbn: vi.fn().mockRejectedValue(error),
-        createBookRecord: vi.fn(),
+        registerIfAbsent: vi.fn().mockRejectedValue(error),
       };
       const app = createTestApp(mockService);
 

--- a/packages/server/tests/unit/books-route.test.ts
+++ b/packages/server/tests/unit/books-route.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import request from "supertest";
 import type { BookData } from "@techbook-ledger/shared";
-import type { NotionPage } from "../../src/services/notion-client.js";
 import {
   NotionAuthError,
   NotionRateLimitError,
@@ -34,10 +33,9 @@ function createMockBookService(
   overrides: Partial<BookService> = {},
 ): BookService {
   return {
-    queryByIsbn: vi.fn().mockResolvedValue(null),
-    createBookRecord: vi
+    registerIfAbsent: vi
       .fn()
-      .mockResolvedValue("https://www.notion.so/new-page"),
+      .mockResolvedValue({ created: true, notionUrl: "https://www.notion.so/new-page" }),
     ...overrides,
   };
 }
@@ -67,13 +65,13 @@ describe("POST /api/books", () => {
       });
     });
 
-    it("should call createBookRecord with the book data", async () => {
+    it("should call registerIfAbsent with the book data", async () => {
       const app = createTestApp(mockService);
       const bookData = createValidBookData();
 
       await request(app).post("/api/books").send(bookData).expect(201);
 
-      expect(mockService.createBookRecord).toHaveBeenCalledWith(bookData);
+      expect(mockService.registerIfAbsent).toHaveBeenCalledWith(bookData);
     });
   });
 
@@ -116,23 +114,22 @@ describe("POST /api/books", () => {
       expect(response.body.message).toContain("isbn");
     });
 
-    it("should not call queryByIsbn when validation fails", async () => {
+    it("should not call registerIfAbsent when validation fails", async () => {
       const app = createTestApp(mockService);
 
       await request(app).post("/api/books").send({}).expect(400);
 
-      expect(mockService.queryByIsbn).not.toHaveBeenCalled();
+      expect(mockService.registerIfAbsent).not.toHaveBeenCalled();
     });
   });
 
   describe("duplicate detection", () => {
     it("should return 200 with isDuplicate when book already exists", async () => {
-      const existingPage: NotionPage = {
-        id: "existing-page-id",
-        url: "https://www.notion.so/existing-page",
-      };
       mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockResolvedValue(existingPage),
+        registerIfAbsent: vi.fn().mockResolvedValue({
+          created: false,
+          notionUrl: "https://www.notion.so/existing-page",
+        }),
       });
       const app = createTestApp(mockService);
       const bookData = createValidBookData();
@@ -149,28 +146,12 @@ describe("POST /api/books", () => {
         isDuplicate: true,
       });
     });
-
-    it("should not call createBookRecord when duplicate is detected", async () => {
-      const existingPage: NotionPage = {
-        id: "existing-page-id",
-        url: "https://www.notion.so/existing-page",
-      };
-      mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockResolvedValue(existingPage),
-      });
-      const app = createTestApp(mockService);
-      const bookData = createValidBookData();
-
-      await request(app).post("/api/books").send(bookData).expect(200);
-
-      expect(mockService.createBookRecord).not.toHaveBeenCalled();
-    });
   });
 
   describe("Notion API error handling", () => {
     it("should return 500 on NotionAuthError", async () => {
       mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockRejectedValue(
+        registerIfAbsent: vi.fn().mockRejectedValue(
           new NotionAuthError("Notion認証に失敗しました。環境変数を確認してください"),
         ),
       });
@@ -190,7 +171,7 @@ describe("POST /api/books", () => {
 
     it("should return 429 on NotionRateLimitError", async () => {
       mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockRejectedValue(
+        registerIfAbsent: vi.fn().mockRejectedValue(
           new NotionRateLimitError(
             "Notion APIがビジー状態です。しばらく待ってから再試行してください",
           ),
@@ -213,7 +194,7 @@ describe("POST /api/books", () => {
 
     it("should return 503 on NotionConnectionError", async () => {
       mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockRejectedValue(
+        registerIfAbsent: vi.fn().mockRejectedValue(
           new NotionConnectionError(
             "Notionに接続できません。ネットワーク接続を確認してください",
           ),
@@ -236,7 +217,7 @@ describe("POST /api/books", () => {
 
     it("should return 500 on unexpected errors", async () => {
       mockService = createMockBookService({
-        queryByIsbn: vi.fn().mockRejectedValue(new Error("unexpected")),
+        registerIfAbsent: vi.fn().mockRejectedValue(new Error("unexpected")),
       });
       const app = createTestApp(mockService);
       const bookData = createValidBookData();
@@ -248,26 +229,6 @@ describe("POST /api/books", () => {
 
       expect(response.body.success).toBe(false);
       expect(response.body.message).toBe("予期しないエラーが発生しました");
-    });
-
-    it("should return 500 on NotionAuthError from createBookRecord", async () => {
-      mockService = createMockBookService({
-        createBookRecord: vi.fn().mockRejectedValue(
-          new NotionAuthError("Notion認証に失敗しました。環境変数を確認してください"),
-        ),
-      });
-      const app = createTestApp(mockService);
-      const bookData = createValidBookData();
-
-      const response = await request(app)
-        .post("/api/books")
-        .send(bookData)
-        .expect(500);
-
-      expect(response.body).toEqual({
-        success: false,
-        message: "Notion認証に失敗しました。環境変数を確認してください",
-      });
     });
   });
 
@@ -322,24 +283,15 @@ describe("POST /api/books", () => {
   });
 
   describe("request flow", () => {
-    it("should follow validate -> duplicate check -> create flow", async () => {
-      const callOrder: string[] = [];
-      mockService = {
-        queryByIsbn: vi.fn().mockImplementation(async () => {
-          callOrder.push("queryByIsbn");
-          return null;
-        }),
-        createBookRecord: vi.fn().mockImplementation(async () => {
-          callOrder.push("createBookRecord");
-          return "https://www.notion.so/new-page";
-        }),
-      };
+    it("should follow validate -> registerIfAbsent flow", async () => {
+      mockService = createMockBookService();
       const app = createTestApp(mockService);
       const bookData = createValidBookData();
 
       await request(app).post("/api/books").send(bookData).expect(201);
 
-      expect(callOrder).toEqual(["queryByIsbn", "createBookRecord"]);
+      expect(mockService.registerIfAbsent).toHaveBeenCalledTimes(1);
+      expect(mockService.registerIfAbsent).toHaveBeenCalledWith(bookData);
     });
   });
 });

--- a/packages/server/tests/unit/isbn-lock.test.ts
+++ b/packages/server/tests/unit/isbn-lock.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { withIsbnLock } from "../../src/utils/isbn-lock.js";
+
+describe("withIsbnLock", () => {
+  it("should execute the function and return its result", async () => {
+    const result = await withIsbnLock("9784297138189", async () => "done");
+    expect(result).toBe("done");
+  });
+
+  it("should serialize concurrent calls with the same ISBN", async () => {
+    const order: number[] = [];
+
+    const task1 = withIsbnLock("9784297138189", async () => {
+      order.push(1);
+      await new Promise((r) => setTimeout(r, 50));
+      order.push(2);
+      return "first";
+    });
+
+    const task2 = withIsbnLock("9784297138189", async () => {
+      order.push(3);
+      return "second";
+    });
+
+    const [result1, result2] = await Promise.all([task1, task2]);
+
+    expect(result1).toBe("first");
+    expect(result2).toBe("second");
+    // task1 must fully complete before task2 starts
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("should allow concurrent calls with different ISBNs", async () => {
+    const order: string[] = [];
+
+    const task1 = withIsbnLock("isbn-a", async () => {
+      order.push("a-start");
+      await new Promise((r) => setTimeout(r, 50));
+      order.push("a-end");
+      return "a";
+    });
+
+    const task2 = withIsbnLock("isbn-b", async () => {
+      order.push("b-start");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("b-end");
+      return "b";
+    });
+
+    const [result1, result2] = await Promise.all([task1, task2]);
+
+    expect(result1).toBe("a");
+    expect(result2).toBe("b");
+    // b should finish before a (shorter delay), proving they run in parallel
+    expect(order.indexOf("b-end")).toBeLessThan(order.indexOf("a-end"));
+  });
+
+  it("should release lock even if function throws", async () => {
+    await expect(
+      withIsbnLock("9784297138189", async () => {
+        throw new Error("test error");
+      }),
+    ).rejects.toThrow("test error");
+
+    // Lock should be released - next call should succeed immediately
+    const result = await withIsbnLock("9784297138189", async () => "recovered");
+    expect(result).toBe("recovered");
+  });
+
+  it("should normalize lock keys case-insensitively", async () => {
+    const order: number[] = [];
+
+    const task1 = withIsbnLock("4-87311-336-X", async () => {
+      order.push(1);
+      await new Promise((r) => setTimeout(r, 30));
+      order.push(2);
+      return "first";
+    });
+
+    const task2 = withIsbnLock("4-87311-336-x", async () => {
+      order.push(3);
+      return "second";
+    });
+
+    await Promise.all([task1, task2]);
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/server/tests/unit/notion-client-register.test.ts
+++ b/packages/server/tests/unit/notion-client-register.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BookData } from "@techbook-ledger/shared";
+
+const mockDatabasesQuery = vi.fn();
+const mockPagesCreate = vi.fn();
+
+vi.mock("@notionhq/client", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    databases: { query: mockDatabasesQuery },
+    pages: { create: mockPagesCreate },
+  })),
+  APIErrorCode: {
+    Unauthorized: "unauthorized",
+    RateLimited: "rate_limited",
+    ServiceUnavailable: "service_unavailable",
+    ObjectNotFound: "object_not_found",
+  },
+  isNotionClientError: (error: unknown): boolean => {
+    return error instanceof Error && "code" in error;
+  },
+}));
+
+import { NotionBookClient } from "../../src/services/notion-client.js";
+
+function createBookData(overrides: Partial<BookData> = {}): BookData {
+  return {
+    isbn: "9784297138189",
+    title: "プロフェッショナルWebプログラミング TypeScript",
+    author: "山田太郎",
+    publisher: "技術評論社",
+    price: 3520,
+    publicationDate: "2024-03-15",
+    pageCount: 432,
+    sourceUrl: "https://gihyo.jp/book/2024/978-4-297-13818-9",
+    ...overrides,
+  };
+}
+
+function createClient(): NotionBookClient {
+  return new NotionBookClient({
+    token: "secret_test",
+    databaseId: "db-id",
+    retryDelayMs: 0,
+  });
+}
+
+describe("NotionBookClient.registerIfAbsent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create a new record when ISBN does not exist", async () => {
+    mockDatabasesQuery.mockResolvedValueOnce({ results: [] });
+    mockPagesCreate.mockResolvedValueOnce({
+      id: "new-page-id",
+      url: "https://www.notion.so/new-page-id",
+    });
+
+    const client = createClient();
+    const result = await client.registerIfAbsent(createBookData());
+
+    expect(result).toEqual({
+      created: true,
+      notionUrl: "https://www.notion.so/new-page-id",
+    });
+    expect(mockDatabasesQuery).toHaveBeenCalledTimes(1);
+    expect(mockPagesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return existing record when ISBN already exists", async () => {
+    mockDatabasesQuery.mockResolvedValueOnce({
+      results: [
+        {
+          id: "existing-page-id",
+          url: "https://www.notion.so/existing-page-id",
+        },
+      ],
+    });
+
+    const client = createClient();
+    const result = await client.registerIfAbsent(createBookData());
+
+    expect(result).toEqual({
+      created: false,
+      notionUrl: "https://www.notion.so/existing-page-id",
+    });
+    expect(mockDatabasesQuery).toHaveBeenCalledTimes(1);
+    expect(mockPagesCreate).not.toHaveBeenCalled();
+  });
+
+  it("should propagate query errors", async () => {
+    const error = new Error("Notion API error: unauthorized");
+    Object.assign(error, { code: "unauthorized", status: 401 });
+    mockDatabasesQuery.mockRejectedValueOnce(error);
+
+    const client = createClient();
+
+    await expect(client.registerIfAbsent(createBookData())).rejects.toThrow(
+      "Notion認証に失敗しました",
+    );
+  });
+
+  it("should propagate create errors", async () => {
+    mockDatabasesQuery.mockResolvedValueOnce({ results: [] });
+
+    const error = new Error("Notion API error: service_unavailable");
+    Object.assign(error, { code: "service_unavailable", status: 503 });
+    mockPagesCreate.mockRejectedValueOnce(error);
+
+    const client = createClient();
+
+    await expect(client.registerIfAbsent(createBookData())).rejects.toThrow(
+      "Notionに接続できません",
+    );
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export {
   type RegistrationResponse,
   type ValidationResult,
   type DuplicateCheckResult,
+  type RegisterResult,
   type ServerConfig,
   type ExtensionConfig,
 } from "./types/index.js";

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -15,3 +15,7 @@ export interface DuplicateCheckResult {
   readonly notionPageId?: string;
   readonly notionUrl?: string;
 }
+
+export type RegisterResult =
+  | { readonly created: true; readonly notionUrl: string }
+  | { readonly created: false; readonly notionUrl: string };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,5 +3,6 @@ export {
   type RegistrationResponse,
   type ValidationResult,
   type DuplicateCheckResult,
+  type RegisterResult,
 } from "./api.js";
 export { type ServerConfig, type ExtensionConfig } from "./config.js";

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -120,3 +120,25 @@
 | type-check | ✅ Success (shared, server, extension) |
 | テスト | ✅ 106 passed (server 84 + extension 22) |
 | ビルド | ✅ shared dist/ 生成確認 (.d.ts x2) |
+
+---
+
+# Task 5.6: 重複チェックのアトミック化
+
+## Plan
+- [x] isbn-lock.ts の TDD (RED → GREEN)
+- [x] RegisterResult 型を shared に追加
+- [x] NotionBookClient.registerIfAbsent() の TDD (RED → GREEN)
+- [x] BookService インターフェースを registerIfAbsent に変更
+- [x] ルートハンドラを registerIfAbsent に切り替え
+- [x] books-route テスト・property テストを更新
+- [x] 品質確認 (lint, typecheck, test, coverage)
+
+## Review
+
+| チェック | 結果 |
+|---------|------|
+| lint | 0 errors, 0 warnings |
+| type-check | Success (shared, server) |
+| テスト | 116 passed (10 suites) |
+| カバレッジ | 87.76% (閾値 80% クリア) |


### PR DESCRIPTION
## Summary
- ISBN 単位の in-memory ロック (`withIsbnLock`) で同一 ISBN の並行リクエストを直列化
- `NotionBookClient.registerIfAbsent()` で query + create をアトミックに実行し、二重登録を防止
- `BookService` インターフェースを `registerIfAbsent` に簡素化し、ルートハンドラを整理
- `RegisterResult` 型を `@techbook-ledger/shared` に追加

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `packages/server/src/utils/isbn-lock.ts` | 新規: ISBN キー単位の in-memory ロック |
| `packages/server/src/services/notion-client.ts` | `registerIfAbsent()` メソッド追加 |
| `packages/server/src/routes/books.ts` | `BookService` を `registerIfAbsent` に変更、ルート簡素化 |
| `packages/shared/src/types/api.ts` | `RegisterResult` 型追加 |
| `packages/server/tests/unit/isbn-lock.test.ts` | 新規: 並行実行の直列化テスト (5 tests) |
| `packages/server/tests/unit/notion-client-register.test.ts` | 新規: registerIfAbsent テスト (4 tests) |
| `packages/server/tests/unit/books-route.test.ts` | registerIfAbsent ベースに更新 |
| `packages/server/tests/property/books-route.test.ts` | registerIfAbsent ベースに更新 |

## Test plan
- [x] `pnpm run test:f server` - 116 tests passed (10 suites)
- [x] `pnpm run typecheck:f server` - pass
- [x] `pnpm lint` - 0 errors, 0 warnings
- [x] `pnpm run test:coverage:f server` - 87.76% (threshold 80%)

Closes task 5.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now serializes concurrent requests per ISBN to prevent duplicate entries; improved HTTP responses (201 for new, 200 for duplicates).

* **New Features**
  * Single-step registration flow that consistently reports creation status and record URL.

* **Tests**
  * Added unit and integration tests covering registration, locking behavior, error propagation, and duplicate handling.

* **Documentation**
  * Task checklist updated to reflect progress on duplicate-check atomicization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->