### PR TITLE
feat(extension): Settings Pageの実装 (Task 12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vitest/coverage-v8": "3.2.4",
     "eslint": "^9.20.0",
     "fast-check": "^3.23.0",
+    "jsdom": "^28.1.0",
     "prettier": "^3.5.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.24.0",

--- a/packages/extension/src/settings/index.html
+++ b/packages/extension/src/settings/index.html
@@ -8,21 +8,30 @@
   </head>
   <body>
     <div id="app">
-      <h1>設定</h1>
+      <h1>TechBook Ledger 設定</h1>
       <form id="settings-form">
         <div class="form-group">
           <label for="server-endpoint">サーバーエンドポイント</label>
           <input
-            type="url"
+            type="text"
             id="server-endpoint"
             placeholder="http://localhost:3000"
           />
+          <p class="hint">
+            localhostまたは127.0.0.1のHTTP URLのみ指定可能です
+          </p>
         </div>
         <div class="form-group">
-          <label for="whitelist">ホワイトリスト（1行に1ドメイン）</label>
-          <textarea id="whitelist" rows="5"></textarea>
+          <label for="whitelist"
+            >ホワイトリスト（1行に1ドメイン、ワイルドカード対応）</label
+          >
+          <textarea
+            id="whitelist"
+            rows="6"
+            placeholder="amazon.co.jp&#10;gihyo.jp&#10;*.amazon.co.jp"
+          ></textarea>
         </div>
-        <button type="submit">保存</button>
+        <button type="submit" id="save-button">保存</button>
         <div id="message"></div>
       </form>
     </div>

--- a/packages/extension/src/settings/settings.css
+++ b/packages/extension/src/settings/settings.css
@@ -1,1 +1,115 @@
-/* Settings page styles - to be implemented in Task 12 */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  background-color: #f5f5f5;
+  color: #333;
+  line-height: 1.6;
+}
+
+#app {
+  max-width: 560px;
+  margin: 40px auto;
+  padding: 32px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  color: #1a1a1a;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  color: #555;
+}
+
+input[type="text"],
+textarea {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: inherit;
+  transition: border-color 0.2s;
+}
+
+input[type="text"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: #4a90d9;
+  box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.hint {
+  font-size: 12px;
+  color: #888;
+  margin-top: 4px;
+}
+
+button[type="submit"] {
+  display: inline-block;
+  padding: 8px 24px;
+  background-color: #4a90d9;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button[type="submit"]:hover {
+  background-color: #357abd;
+}
+
+button[type="submit"]:active {
+  background-color: #2a6099;
+}
+
+#message {
+  margin-top: 12px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  min-height: 20px;
+}
+
+#message:empty {
+  display: none;
+}
+
+#message.success {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  border: 1px solid #c8e6c9;
+}
+
+#message.error {
+  background-color: #fbe9e7;
+  color: #c62828;
+  border: 1px solid #ffccbc;
+}

--- a/packages/extension/src/settings/settings.ts
+++ b/packages/extension/src/settings/settings.ts
@@ -1,1 +1,125 @@
-// Settings page logic - to be implemented in Task 12
+import { loadConfig, saveConfig } from "../storage/config.js";
+
+/**
+ * Validate that the given URL is a valid localhost HTTP endpoint.
+ * Only http://localhost[:port] and http://127.0.0.1[:port] are accepted.
+ * No paths, query strings, or fragments are allowed.
+ */
+export function validateEndpoint(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:") {
+    return false;
+  }
+
+  if (parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
+    return false;
+  }
+
+  // Reject paths, query strings, fragments
+  if (parsed.pathname !== "/" || parsed.search !== "" || parsed.hash !== "") {
+    return false;
+  }
+
+  // Validate port range if specified
+  if (parsed.port !== "") {
+    const port = Number(parsed.port);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return false;
+    }
+  }
+
+  // Reconstruct expected URL to ensure no extra content
+  const expectedWithPort = parsed.port
+    ? `http://${parsed.hostname}:${parsed.port}`
+    : `http://${parsed.hostname}`;
+
+  return url.trim() === expectedWithPort;
+}
+
+/**
+ * Initialize the settings page: load current config, populate form,
+ * attach submit handler for saving.
+ */
+export async function initSettings(): Promise<void> {
+  const config = await loadConfig();
+
+  const endpointInput = document.getElementById("server-endpoint");
+  const whitelistTextarea = document.getElementById("whitelist");
+  const form = document.getElementById("settings-form");
+  const messageDiv = document.getElementById("message");
+
+  if (
+    !(endpointInput instanceof HTMLInputElement) ||
+    !(whitelistTextarea instanceof HTMLTextAreaElement) ||
+    !(form instanceof HTMLFormElement) ||
+    !(messageDiv instanceof HTMLDivElement)
+  ) {
+    return;
+  }
+
+  // Populate form with current settings
+  endpointInput.value = config.serverEndpoint;
+  whitelistTextarea.value = config.whitelist.join("\n");
+
+  // Handle form submission
+  form.addEventListener("submit", async (event: Event) => {
+    event.preventDefault();
+
+    const endpoint = endpointInput.value.trim();
+    const whitelistRaw = whitelistTextarea.value;
+
+    // Validate endpoint
+    if (!validateEndpoint(endpoint)) {
+      messageDiv.textContent =
+        "エンドポイントはlocalhostまたは127.0.0.1のHTTP URLを指定してください";
+      messageDiv.className = "error";
+      return;
+    }
+
+    // Parse whitelist: split by newlines, trim, remove empty entries
+    const whitelist = whitelistRaw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    // Save settings
+    try {
+      await saveConfig({
+        serverEndpoint: endpoint,
+        whitelist,
+      });
+      messageDiv.textContent = "設定を保存しました";
+      messageDiv.className = "success";
+    } catch {
+      messageDiv.textContent =
+        "設定の保存に失敗しました。再度お試しください。";
+      messageDiv.className = "error";
+    }
+  });
+}
+
+// Auto-initialize when loaded in browser (guard against missing DOM elements)
+function autoInit(): void {
+  const form = document.getElementById("settings-form");
+  if (form) {
+    void initSettings().catch(() => {
+      const messageDiv = document.getElementById("message");
+      if (messageDiv instanceof HTMLDivElement) {
+        messageDiv.textContent = "設定の読み込みに失敗しました。";
+        messageDiv.className = "error";
+      }
+    });
+  }
+}
+
+if (typeof document !== "undefined" && document.readyState !== "loading") {
+  autoInit();
+} else if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", autoInit);
+}

--- a/packages/extension/tests/property/settings.test.ts
+++ b/packages/extension/tests/property/settings.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+
+import { validateEndpoint } from "../../src/settings/settings.js";
+
+// Arbitraries for generating valid localhost URLs
+const validPortArb = fc.integer({ min: 1, max: 65535 });
+
+const validLocalhostEndpointArb = fc.oneof(
+  validPortArb.map((port) => `http://localhost:${port}`),
+  validPortArb.map((port) => `http://127.0.0.1:${port}`),
+);
+
+const validLocalhostNoPortArb = fc.constantFrom(
+  "http://localhost",
+  "http://127.0.0.1",
+);
+
+const validEndpointArb = fc.oneof(
+  validLocalhostEndpointArb,
+  validLocalhostNoPortArb,
+);
+
+// Arbitraries for generating invalid URLs
+
+// Non-localhost hostnames
+const nonLocalhostHostArb = fc
+  .tuple(
+    fc.stringOf(
+      fc.constantFrom(...("abcdefghijklmnopqrstuvwxyz".split(""))),
+      { minLength: 2, maxLength: 10 },
+    ),
+    fc.constantFrom(".com", ".co.jp", ".jp", ".org", ".net", ".io"),
+  )
+  .map(([name, tld]) => name + tld);
+
+const nonLocalhostUrlArb = fc
+  .tuple(nonLocalhostHostArb, validPortArb)
+  .map(([host, port]) => `http://${host}:${port}`);
+
+// HTTPS URLs (not allowed for localhost)
+const httpsLocalhostArb = fc.oneof(
+  validPortArb.map((port) => `https://localhost:${port}`),
+  validPortArb.map((port) => `https://127.0.0.1:${port}`),
+);
+
+// Non-URL strings
+const nonUrlArb = fc.oneof(
+  fc.constant(""),
+  fc.constant("not-a-url"),
+  fc.constant("ftp://localhost:3000"),
+  fc.stringOf(
+    fc.constantFrom(...("abcdefghijklmnopqrstuvwxyz0123456789".split(""))),
+    { minLength: 1, maxLength: 20 },
+  ),
+);
+
+describe("Feature: tech-book-decision-support, Property 19: エンドポイント形式検証", () => {
+  it("should accept all valid localhost HTTP URLs", async () => {
+    await fc.assert(
+      fc.asyncProperty(validEndpointArb, async (url) => {
+        expect(validateEndpoint(url)).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should reject all non-localhost URLs", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonLocalhostUrlArb, async (url) => {
+        expect(validateEndpoint(url)).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should reject all HTTPS localhost URLs", async () => {
+    await fc.assert(
+      fc.asyncProperty(httpsLocalhostArb, async (url) => {
+        expect(validateEndpoint(url)).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("should reject all non-URL strings", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonUrlArb, async (input) => {
+        expect(validateEndpoint(input)).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/extension/tests/unit/settings.test.ts
+++ b/packages/extension/tests/unit/settings.test.ts
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type { ExtensionConfig } from "@techbook-ledger/shared";
+
+// Mock chrome.storage.sync API
+const mockStorage: Record<string, unknown> = {};
+
+const chromeMock = {
+  storage: {
+    sync: {
+      get: vi.fn(
+        (
+          keys: string | string[] | Record<string, unknown> | null,
+        ): Promise<Record<string, unknown>> => {
+          if (keys === null) {
+            return Promise.resolve({ ...mockStorage });
+          }
+          if (typeof keys === "string") {
+            return Promise.resolve(
+              keys in mockStorage ? { [keys]: mockStorage[keys] } : {},
+            );
+          }
+          if (Array.isArray(keys)) {
+            const result: Record<string, unknown> = {};
+            for (const key of keys) {
+              if (key in mockStorage) {
+                result[key] = mockStorage[key];
+              }
+            }
+            return Promise.resolve(result);
+          }
+          // Record<string, unknown> → use defaults for missing keys
+          const result: Record<string, unknown> = {};
+          for (const [key, defaultValue] of Object.entries(
+            keys as Record<string, unknown>,
+          )) {
+            result[key] = key in mockStorage ? mockStorage[key] : defaultValue;
+          }
+          return Promise.resolve(result);
+        },
+      ),
+      set: vi.fn((items: Record<string, unknown>): Promise<void> => {
+        Object.assign(mockStorage, items);
+        return Promise.resolve();
+      }),
+    },
+  },
+  runtime: {
+    lastError: null as chrome.runtime.LastError | null,
+  },
+};
+
+vi.stubGlobal("chrome", chromeMock);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// Import after mocking chrome
+const { validateEndpoint, initSettings } = await import(
+  "../../src/settings/settings.js"
+);
+
+describe("validateEndpoint", () => {
+  it("should accept http://localhost:3000", () => {
+    expect(validateEndpoint("http://localhost:3000")).toBe(true);
+  });
+
+  it("should accept http://localhost:8080", () => {
+    expect(validateEndpoint("http://localhost:8080")).toBe(true);
+  });
+
+  it("should accept http://127.0.0.1:3000", () => {
+    expect(validateEndpoint("http://127.0.0.1:3000")).toBe(true);
+  });
+
+  it("should accept http://127.0.0.1:8080", () => {
+    expect(validateEndpoint("http://127.0.0.1:8080")).toBe(true);
+  });
+
+  it("should accept http://localhost without port", () => {
+    expect(validateEndpoint("http://localhost")).toBe(true);
+  });
+
+  it("should accept http://127.0.0.1 without port", () => {
+    expect(validateEndpoint("http://127.0.0.1")).toBe(true);
+  });
+
+  it("should reject https://localhost:3000", () => {
+    expect(validateEndpoint("https://localhost:3000")).toBe(false);
+  });
+
+  it("should reject https://127.0.0.1:3000", () => {
+    expect(validateEndpoint("https://127.0.0.1:3000")).toBe(false);
+  });
+
+  it("should reject http://example.com:3000", () => {
+    expect(validateEndpoint("http://example.com:3000")).toBe(false);
+  });
+
+  it("should reject http://192.168.1.1:3000", () => {
+    expect(validateEndpoint("http://192.168.1.1:3000")).toBe(false);
+  });
+
+  it("should reject empty string", () => {
+    expect(validateEndpoint("")).toBe(false);
+  });
+
+  it("should reject non-URL strings", () => {
+    expect(validateEndpoint("not-a-url")).toBe(false);
+  });
+
+  it("should reject ftp://localhost:3000", () => {
+    expect(validateEndpoint("ftp://localhost:3000")).toBe(false);
+  });
+
+  it("should reject URLs with paths", () => {
+    expect(validateEndpoint("http://localhost:3000/api")).toBe(false);
+  });
+
+  it("should reject URLs with trailing slash", () => {
+    expect(validateEndpoint("http://localhost:3000/")).toBe(false);
+  });
+
+  it("should reject URLs with query parameters", () => {
+    expect(validateEndpoint("http://localhost:3000?key=val")).toBe(false);
+  });
+
+  it("should reject port 0", () => {
+    expect(validateEndpoint("http://localhost:0")).toBe(false);
+  });
+
+  it("should reject port above 65535", () => {
+    expect(validateEndpoint("http://localhost:99999")).toBe(false);
+  });
+});
+
+describe("Settings page: initSettings", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockStorage)) {
+      delete mockStorage[key];
+    }
+    vi.clearAllMocks();
+
+    // Set up minimal DOM
+    document.body.innerHTML = `
+      <form id="settings-form">
+        <input type="text" id="server-endpoint" />
+        <textarea id="whitelist"></textarea>
+        <button type="submit">保存</button>
+        <div id="message"></div>
+      </form>
+    `;
+  });
+
+  it("should populate form with default config when storage is empty", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+
+    expect(endpointInput.value).toBe("http://localhost:3000");
+    expect(whitelistTextarea.value).toBe("amazon.co.jp\ngihyo.jp\n*.amazon.co.jp");
+  });
+
+  it("should populate form with stored config", async () => {
+    const customConfig: ExtensionConfig = {
+      serverEndpoint: "http://localhost:8080",
+      whitelist: ["example.com", "*.test.jp"],
+    };
+    mockStorage["extensionConfig"] = customConfig;
+
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+
+    expect(endpointInput.value).toBe("http://localhost:8080");
+    expect(whitelistTextarea.value).toBe("example.com\n*.test.jp");
+  });
+
+  it("should save valid settings when form is submitted", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:4000";
+    whitelistTextarea.value = "bookstore.jp\n*.shop.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    // Wait for async save to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      extensionConfig: {
+        serverEndpoint: "http://localhost:4000",
+        whitelist: ["bookstore.jp", "*.shop.co.jp"],
+      },
+    });
+  });
+
+  it("should show success message after saving", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:3000";
+    whitelistTextarea.value = "amazon.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const message = document.getElementById("message") as HTMLDivElement;
+    expect(message.textContent).toBe("設定を保存しました");
+    expect(message.classList.contains("success")).toBe(true);
+  });
+
+  it("should show error message when endpoint is invalid", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://example.com:3000";
+    whitelistTextarea.value = "amazon.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const message = document.getElementById("message") as HTMLDivElement;
+    expect(message.textContent).toBe(
+      "エンドポイントはlocalhostまたは127.0.0.1のHTTP URLを指定してください",
+    );
+    expect(message.classList.contains("error")).toBe(true);
+  });
+
+  it("should not save when endpoint is invalid", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "https://malicious.com";
+    whitelistTextarea.value = "amazon.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).not.toHaveBeenCalled();
+  });
+
+  it("should filter out empty lines from whitelist", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:3000";
+    whitelistTextarea.value = "amazon.co.jp\n\ngihyo.jp\n\n";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      extensionConfig: {
+        serverEndpoint: "http://localhost:3000",
+        whitelist: ["amazon.co.jp", "gihyo.jp"],
+      },
+    });
+  });
+
+  it("should trim whitespace from whitelist entries", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:3000";
+    whitelistTextarea.value = "  amazon.co.jp  \n  gihyo.jp  ";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      extensionConfig: {
+        serverEndpoint: "http://localhost:3000",
+        whitelist: ["amazon.co.jp", "gihyo.jp"],
+      },
+    });
+  });
+
+  it("should allow saving empty whitelist", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:3000";
+    whitelistTextarea.value = "";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      extensionConfig: {
+        serverEndpoint: "http://localhost:3000",
+        whitelist: [],
+      },
+    });
+  });
+
+  it("should trim whitespace from endpoint URL", async () => {
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "  http://localhost:3000  ";
+    whitelistTextarea.value = "amazon.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      extensionConfig: {
+        serverEndpoint: "http://localhost:3000",
+        whitelist: ["amazon.co.jp"],
+      },
+    });
+  });
+
+  it("should show error message when saveConfig fails", async () => {
+    chromeMock.storage.sync.set.mockRejectedValueOnce(new Error("storage error"));
+
+    await initSettings();
+
+    const endpointInput = document.getElementById("server-endpoint") as HTMLInputElement;
+    const whitelistTextarea = document.getElementById("whitelist") as HTMLTextAreaElement;
+    const form = document.getElementById("settings-form") as HTMLFormElement;
+
+    endpointInput.value = "http://localhost:3000";
+    whitelistTextarea.value = "amazon.co.jp";
+
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const message = document.getElementById("message") as HTMLDivElement;
+    expect(message.textContent).toBe("設定の保存に失敗しました。再度お試しください。");
+    expect(message.classList.contains("error")).toBe(true);
+  });
+
+  it("should return early when required DOM elements are missing", async () => {
+    document.body.innerHTML = "<div>no form here</div>";
+
+    await initSettings();
+
+    expect(chromeMock.storage.sync.get).toHaveBeenCalled();
+    expect(chromeMock.storage.sync.set).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       fast-check:
         specifier: ^3.23.0
         version: 3.23.2
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       prettier:
         specifier: ^3.5.0
         version: 3.8.1

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -248,3 +248,35 @@
 - TDD: テストファースト、Red→Green→Refactor
 - fast-check: 各プロパティ100回以上の反復
 - カバレッジ: 80%以上
+
+---
+
+# Task 12: Settings Pageの実装
+
+## Plan
+- [x] 12.3 Property 19: エンドポイント形式検証テストの作成 (tests/property/settings.test.ts) - RED
+- [x] 12.1/12.2 ユニットテスト作成 (tests/unit/settings.test.ts) - RED
+  - validateEndpoint() のバリデーション検証
+  - Settings ページ初期化・フォーム操作・保存フロー検証
+- [x] 12.2 validateEndpoint() 実装 (src/settings/settings.ts) - GREEN
+  - localhost / 127.0.0.1 の HTTP URL のみ受け入れ
+  - パス・クエリ・フラグメント・不正ポートの拒否
+- [x] 12.2 initSettings() 実装 (src/settings/settings.ts) - GREEN
+  - Extension Storage から設定読込・フォーム反映
+  - submit ハンドラでバリデーション → 保存 → メッセージ表示
+  - 空行・空白のトリム、設定の即時反映
+- [x] 12.1 Settings UI の作成 (index.html, settings.css)
+  - エンドポイント入力、ホワイトリスト編集、保存ボタン
+  - ヒントテキスト、成功/エラーメッセージスタイル
+- [x] 品質確認 (lint, typecheck, test, coverage, build)
+- [ ] E2E テスト (deferred: Playwright 基盤構築後に実施)
+
+## Review
+
+| チェック | 結果 |
+|---------|------|
+| lint | 0 errors, 0 warnings |
+| type-check | Success (shared, server, extension) |
+| テスト | 170 passed (extension 54, server 116) |
+| カバレッジ | settings.ts 94.59%/84.37%/100%/94.59%, 全体 96.22% |
+| ビルド | Build successful (shared, server, extension) |


### PR DESCRIPTION
## 概要

Chrome拡張機能の設定ページ（Settings Page）をTDDで実装しました。サーバーエンドポイントの設定とホワイトリスト編集が可能です。

## 背景・目的

Task 12（Settings Pageの実装）として、Requirements 10.1〜10.5 を満たす設定管理機能を提供します。

## 変更内容

- **validateEndpoint()**: localhost / 127.0.0.1 の HTTP URL のみ受け入れるバリデーション関数
- **initSettings()**: Extension Storage から設定を読込・フォームに反映し、保存時にバリデーション → 即時反映
- **Settings UI**: エンドポイント入力フォーム、ホワイトリスト編集テキストエリア、保存ボタン、成功/エラーメッセージ表示
- **Property 19 テスト**: エンドポイント形式検証（fast-check 100回反復×4パターン）
- **ユニットテスト**: validateEndpoint 18テスト + Settings ページロジック 10テスト

## スコープ外（やっていないこと）

- Content Script / Popup UI / Service Worker の実装（別タスク）
- E2Eテスト（統合テスト段階で実施予定）

## 動作確認方法

1. `pnpm install` で依存関係をインストール
2. `pnpm run build:f shared` で shared パッケージをビルド
3. `pnpm run test:f extension` でテストを実行（54 passed）
4. `pnpm run test:coverage:f extension` でカバレッジを確認（settings.ts 94.59%/84.37%/100%/94.59%）
5. `pnpm typecheck` で型チェックを確認（全パッケージ Success）
6. `pnpm build` でビルドを確認（全パッケージ成功）

## チェックリスト

- [x] セルフレビュー済み
- [x] テストを追加・更新した（Property 19 + ユニットテスト 28件）
- [x] 既存テストがすべて通る（170 passed）
- [x] カバレッジ 80% 以上を維持（96.22%）
- [x] Breaking Changeなし

## 定量品質確認フォーマット

| チェック | 結果 |
|---------|------|
| lint | ✅ 0 errors, 0 warnings |
| type-check | ✅ Success (shared, server, extension) |
| テスト | ✅ 170 passed (extension 54 + server 116) |
| カバレッジ | ✅ settings.ts 94.59%/84.37%/100%/94.59% |
| ビルド | ✅ Build successful |

## レビュアーへのメモ

- `validateEndpoint()` は URL API を使ってパースし、プロトコル・ホスト名・パス・ポートを厳密に検証しています
- 自動初期化コード（`autoInit`）はフォーム要素の存在をガードしているため、テスト環境では意図しない初期化が発生しません
- jsdom をルートの devDependencies に追加しています（Settings ページの DOM テスト用）

https://claude.ai/code/session_014m3GQKPrJF6xiZdtX6fafK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned settings page: updated header, hint text, whitelist examples (wildcard support), adjusted input types, added save button and polished styling.
  * Endpoint validation enforcing HTTP localhost/127.0.0.1 URLs, trimming whitespace, and improved whitelist parsing and save behavior with user feedback.

* **Tests**
  * Added comprehensive unit and property-based tests covering validation, UI flows, storage, and save feedback.

* **Chores**
  * Added jsdom as a dev dependency.

* **Documentation**
  * Added tasks/documentation entry for Settings implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->