### PR TITLE
feat(extension): Popup UI の実装 #20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,14 @@ pnpm run test:f shared
 pnpm run typecheck:f server
 pnpm run build:f shared
 
-# カバレッジ付きテスト（pnpm exec で直接実行）
+# カバレッジ付きテスト
 pnpm run test:coverage:f server
 
 # 開発サーバー
 pnpm run dev:f server
 
 # 単一テストファイル実行
-pnpm --filter server exec vitest run tests/unit/notion-client.test.ts
+pnpm run test:file server tests/unit/notion-client.test.ts
 ```
 
 **注意**: フィルタスクリプト (`test:f`, `typecheck:f` 等) は `bash -c` + 位置パラメータで実装されている。`--` は付けずに呼び出す。

--- a/packages/extension/src/popup/index.html
+++ b/packages/extension/src/popup/index.html
@@ -9,7 +9,7 @@
   <body>
     <div id="app">
       <h1>TechBook Ledger</h1>
-      <div id="status"></div>
+      <div id="status" class="status inactive"></div>
       <div id="book-info"></div>
       <button id="register-btn" disabled>登録</button>
       <div id="message"></div>

--- a/packages/extension/src/popup/messages.ts
+++ b/packages/extension/src/popup/messages.ts
@@ -1,0 +1,19 @@
+import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
+
+export interface GetBookDataMessage {
+  readonly type: "GET_BOOK_DATA";
+}
+
+export interface GetBookDataResponse {
+  readonly bookData: BookData | null;
+}
+
+export interface RegisterBookMessage {
+  readonly type: "REGISTER_BOOK";
+  readonly bookData: BookData;
+}
+
+export type PopupToContentMessage = GetBookDataMessage;
+export type PopupToBackgroundMessage = RegisterBookMessage;
+
+export type { BookData, RegistrationResponse };

--- a/packages/extension/src/popup/popup-state.ts
+++ b/packages/extension/src/popup/popup-state.ts
@@ -1,0 +1,79 @@
+import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
+
+export type PopupStatus =
+  | "inactive"
+  | "ready"
+  | "loading"
+  | "success"
+  | "error";
+
+export interface PopupState {
+  readonly status: PopupStatus;
+  readonly bookData: BookData | null;
+  readonly message: string;
+}
+
+export function createInitialState(): PopupState {
+  return { status: "inactive", bookData: null, message: "" };
+}
+
+export function derivePopupState(bookData: BookData | null): PopupState {
+  if (bookData === null) {
+    return {
+      status: "inactive",
+      bookData: null,
+      message: "このページは対応していません",
+    };
+  }
+  return { status: "ready", bookData, message: "" };
+}
+
+export function createLoadingState(bookData: BookData): PopupState {
+  return { status: "loading", bookData, message: "" };
+}
+
+export function createResultState(
+  bookData: BookData,
+  response: RegistrationResponse,
+): PopupState {
+  if (response.success || response.isDuplicate) {
+    return { status: "success", bookData, message: response.message };
+  }
+  return { status: "error", bookData, message: response.message };
+}
+
+export function createResetState(bookData: BookData): PopupState {
+  return { status: "ready", bookData, message: "" };
+}
+
+export function formatPrice(price: number): string {
+  return `${price.toLocaleString("ja-JP")}円`;
+}
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function formatBookInfoHtml(bookData: BookData): string {
+  const fields = [
+    { label: "タイトル", value: bookData.title },
+    { label: "著者", value: bookData.author },
+    { label: "出版社", value: bookData.publisher },
+    { label: "ISBN", value: bookData.isbn },
+    { label: "価格", value: formatPrice(bookData.price) },
+    { label: "発売日", value: bookData.publicationDate },
+    { label: "ページ数", value: bookData.pageCount > 0 ? `${bookData.pageCount}p` : "" },
+  ];
+
+  return fields
+    .map(
+      ({ label, value }) =>
+        `<div class="book-field"><span class="book-field-label">${escapeHtml(label)}: </span><span class="book-field-value">${escapeHtml(String(value))}</span></div>`,
+    )
+    .join("");
+}

--- a/packages/extension/src/popup/popup.css
+++ b/packages/extension/src/popup/popup.css
@@ -1,1 +1,153 @@
-/* Popup styles - to be implemented in Task 10 */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  width: 360px;
+  background-color: #f5f5f5;
+  color: #333;
+  line-height: 1.6;
+}
+
+#app {
+  padding: 16px;
+  background: #fff;
+}
+
+h1 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #1a1a1a;
+}
+
+/* Status indicator */
+.status {
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.status.inactive {
+  background-color: #f0f0f0;
+  color: #888;
+}
+
+.status.ready {
+  background-color: #e3f2fd;
+  color: #1565c0;
+}
+
+.status.loading {
+  background-color: #fff3e0;
+  color: #e65100;
+}
+
+.status.success {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status.error {
+  background-color: #fbe9e7;
+  color: #c62828;
+}
+
+/* Book info display */
+#book-info {
+  margin-bottom: 12px;
+}
+
+#book-info:empty {
+  display: none;
+}
+
+.book-field {
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.book-field-label {
+  font-weight: 500;
+  color: #555;
+}
+
+.book-field-value {
+  color: #333;
+}
+
+/* Register button */
+#register-btn {
+  display: block;
+  width: 100%;
+  padding: 8px 24px;
+  background-color: #4a90d9;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#register-btn:hover:not(:disabled) {
+  background-color: #357abd;
+}
+
+#register-btn:active:not(:disabled) {
+  background-color: #2a6099;
+}
+
+#register-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* Message area */
+#message {
+  margin-top: 12px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+#message:empty {
+  display: none;
+}
+
+#message.success {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  border: 1px solid #c8e6c9;
+}
+
+#message.error {
+  background-color: #fbe9e7;
+  color: #c62828;
+  border: 1px solid #ffccbc;
+}
+
+/* Loading spinner */
+.loading-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #e65100;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -1,1 +1,209 @@
-// Popup UI logic - to be implemented in Task 10
+import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
+import type { PopupState } from "./popup-state.js";
+import {
+  createInitialState,
+  derivePopupState,
+  createLoadingState,
+  createResultState,
+  createResetState,
+  formatBookInfoHtml,
+} from "./popup-state.js";
+
+export { formatBookInfoHtml } from "./popup-state.js";
+
+interface PopupElements {
+  readonly statusDiv: HTMLDivElement;
+  readonly bookInfoDiv: HTMLDivElement;
+  readonly registerBtn: HTMLButtonElement;
+  readonly messageDiv: HTMLDivElement;
+}
+
+interface PopupDeps {
+  readonly getBookData?: () => Promise<BookData | null>;
+  readonly registerBook?: (bookData: BookData) => Promise<RegistrationResponse>;
+  readonly scheduleReset?: (callback: () => void, ms: number) => void;
+}
+
+const STATUS_CLASSES = [
+  "inactive",
+  "ready",
+  "loading",
+  "success",
+  "error",
+] as const;
+
+const STATUS_TEXT: Record<PopupState["status"], string> = {
+  inactive: "このページは対応していません",
+  ready: "登録可能",
+  loading: "登録中...",
+  success: "完了",
+  error: "エラー",
+};
+
+function renderState(state: PopupState, elements: PopupElements): void {
+  const { statusDiv, bookInfoDiv, registerBtn, messageDiv } = elements;
+
+  // Update status
+  for (const cls of STATUS_CLASSES) {
+    statusDiv.classList.remove(cls);
+  }
+  statusDiv.classList.add(state.status);
+  statusDiv.textContent = state.message || STATUS_TEXT[state.status];
+
+  // Update book info
+  if (state.bookData) {
+    bookInfoDiv.innerHTML = formatBookInfoHtml(state.bookData);
+  } else {
+    bookInfoDiv.innerHTML = "";
+  }
+
+  // Update register button
+  registerBtn.disabled = state.status !== "ready";
+
+  // Update message
+  if (state.status === "success" || state.status === "error") {
+    messageDiv.textContent = state.message;
+    messageDiv.className = state.status === "success" ? "success" : "error";
+  } else {
+    messageDiv.textContent = "";
+    messageDiv.className = "";
+  }
+}
+
+function getPopupElements(): PopupElements | null {
+  const statusDiv = document.getElementById("status");
+  const bookInfoDiv = document.getElementById("book-info");
+  const registerBtn = document.getElementById("register-btn");
+  const messageDiv = document.getElementById("message");
+
+  if (
+    !(statusDiv instanceof HTMLDivElement) ||
+    !(bookInfoDiv instanceof HTMLDivElement) ||
+    !(registerBtn instanceof HTMLButtonElement) ||
+    !(messageDiv instanceof HTMLDivElement)
+  ) {
+    return null;
+  }
+
+  return { statusDiv, bookInfoDiv, registerBtn, messageDiv };
+}
+
+async function defaultGetBookData(): Promise<BookData | null> {
+  const tabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  const tab = tabs[0];
+  if (!tab?.id) return null;
+
+  const response = await chrome.tabs.sendMessage(tab.id, {
+    type: "GET_BOOK_DATA",
+  });
+  return (response as { bookData: BookData | null })?.bookData ?? null;
+}
+
+async function defaultRegisterBook(
+  bookData: BookData,
+): Promise<RegistrationResponse> {
+  return chrome.runtime.sendMessage({
+    type: "REGISTER_BOOK",
+    bookData,
+  }) as Promise<RegistrationResponse>;
+}
+
+function defaultScheduleReset(callback: () => void, ms: number): void {
+  setTimeout(callback, ms);
+}
+
+export async function initPopup(deps?: PopupDeps): Promise<void> {
+  const elements = getPopupElements();
+  if (!elements) return;
+
+  const getBookData = deps?.getBookData ?? defaultGetBookData;
+  const registerBook = deps?.registerBook ?? defaultRegisterBook;
+  const scheduleReset = deps?.scheduleReset ?? defaultScheduleReset;
+
+  // Render initial state
+  renderState(createInitialState(), elements);
+
+  // Fetch book data from content script
+  let bookData: BookData | null;
+  try {
+    bookData = await getBookData();
+  } catch {
+    renderState(
+      {
+        status: "error",
+        bookData: null,
+        message: "書籍データの取得に失敗しました",
+      },
+      elements,
+    );
+    return;
+  }
+
+  // Derive and render state from book data
+  const state = derivePopupState(bookData);
+  renderState(state, elements);
+
+  if (!bookData) return;
+
+  // Attach click handler for registration
+  elements.registerBtn.addEventListener("click", () => {
+    void handleRegister(bookData, elements, registerBook, scheduleReset);
+  });
+}
+
+async function handleRegister(
+  bookData: BookData,
+  elements: PopupElements,
+  registerBook: (bookData: BookData) => Promise<RegistrationResponse>,
+  scheduleReset: (callback: () => void, ms: number) => void,
+): Promise<void> {
+  // Transition to loading
+  renderState(createLoadingState(bookData), elements);
+
+  let response: RegistrationResponse;
+  try {
+    response = await registerBook(bookData);
+  } catch {
+    renderState(
+      {
+        status: "error",
+        bookData,
+        message: "サーバーとの通信に失敗しました",
+      },
+      elements,
+    );
+    return;
+  }
+
+  // Render result
+  const resultState = createResultState(bookData, response);
+  renderState(resultState, elements);
+
+  // Schedule reset to ready state after 3 seconds
+  scheduleReset(() => {
+    renderState(createResetState(bookData), elements);
+  }, 3000);
+}
+
+// Auto-initialize when loaded in browser
+function autoInit(): void {
+  const status = document.getElementById("status");
+  if (status) {
+    void initPopup().catch(() => {
+      const messageDiv = document.getElementById("message");
+      if (messageDiv instanceof HTMLDivElement) {
+        messageDiv.textContent = "Popup の初期化に失敗しました。";
+        messageDiv.className = "error";
+      }
+    });
+  }
+}
+
+if (typeof document !== "undefined" && document.readyState !== "loading") {
+  autoInit();
+} else if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", autoInit);
+}

--- a/packages/extension/tests/unit/popup-state.test.ts
+++ b/packages/extension/tests/unit/popup-state.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
+import {
+  createInitialState,
+  derivePopupState,
+  createLoadingState,
+  createResultState,
+  createResetState,
+  formatPrice,
+  formatBookInfoHtml,
+  escapeHtml,
+} from "../../src/popup/popup-state.js";
+
+const sampleBookData: BookData = {
+  isbn: "9784297138189",
+  title: "TypeScript入門",
+  author: "鈴木僚太",
+  publisher: "技術評論社",
+  price: 3278,
+  publicationDate: "2022-04-22",
+  pageCount: 424,
+  sourceUrl: "https://gihyo.jp/book/2022/978-4-297-13818-9",
+};
+
+describe("createInitialState", () => {
+  it("should return inactive state with null bookData", () => {
+    const state = createInitialState();
+    expect(state.status).toBe("inactive");
+    expect(state.bookData).toBeNull();
+    expect(state.message).toBe("");
+  });
+});
+
+describe("derivePopupState", () => {
+  it("should return inactive state when bookData is null", () => {
+    const state = derivePopupState(null);
+    expect(state.status).toBe("inactive");
+    expect(state.bookData).toBeNull();
+    expect(state.message).toBe("このページは対応していません");
+  });
+
+  it("should return ready state when bookData is provided", () => {
+    const state = derivePopupState(sampleBookData);
+    expect(state.status).toBe("ready");
+    expect(state.bookData).toEqual(sampleBookData);
+    expect(state.message).toBe("");
+  });
+
+  it("should not mutate the input bookData", () => {
+    const original = { ...sampleBookData };
+    derivePopupState(sampleBookData);
+    expect(sampleBookData).toEqual(original);
+  });
+});
+
+describe("createLoadingState", () => {
+  it("should return loading state with bookData", () => {
+    const state = createLoadingState(sampleBookData);
+    expect(state.status).toBe("loading");
+    expect(state.bookData).toEqual(sampleBookData);
+    expect(state.message).toBe("");
+  });
+});
+
+describe("createResultState", () => {
+  it("should return success state on successful registration", () => {
+    const response: RegistrationResponse = {
+      success: true,
+      message: "書籍を登録しました",
+      notionUrl: "https://notion.so/page-id",
+    };
+    const state = createResultState(sampleBookData, response);
+    expect(state.status).toBe("success");
+    expect(state.bookData).toEqual(sampleBookData);
+    expect(state.message).toBe("書籍を登録しました");
+  });
+
+  it("should return success state with duplicate message on duplicate", () => {
+    const response: RegistrationResponse = {
+      success: false,
+      message: "この書籍は既に登録されています",
+      isDuplicate: true,
+      notionUrl: "https://notion.so/existing-page",
+    };
+    const state = createResultState(sampleBookData, response);
+    expect(state.status).toBe("success");
+    expect(state.message).toBe("この書籍は既に登録されています");
+  });
+
+  it("should return error state on failed registration", () => {
+    const response: RegistrationResponse = {
+      success: false,
+      message: "サーバーに接続できません",
+    };
+    const state = createResultState(sampleBookData, response);
+    expect(state.status).toBe("error");
+    expect(state.bookData).toEqual(sampleBookData);
+    expect(state.message).toBe("サーバーに接続できません");
+  });
+
+  it("should include notionUrl in message when provided on success", () => {
+    const response: RegistrationResponse = {
+      success: true,
+      message: "書籍を登録しました",
+      notionUrl: "https://notion.so/page-id",
+    };
+    const state = createResultState(sampleBookData, response);
+    expect(state.message).toContain("書籍を登録しました");
+  });
+});
+
+describe("createResetState", () => {
+  it("should return ready state with bookData", () => {
+    const state = createResetState(sampleBookData);
+    expect(state.status).toBe("ready");
+    expect(state.bookData).toEqual(sampleBookData);
+    expect(state.message).toBe("");
+  });
+});
+
+describe("formatPrice", () => {
+  it("should return '0円' for zero", () => {
+    expect(formatPrice(0)).toBe("0円");
+  });
+
+  it("should format with comma separators", () => {
+    expect(formatPrice(3278)).toBe("3,278円");
+  });
+
+  it("should handle large numbers", () => {
+    expect(formatPrice(15000)).toBe("15,000円");
+  });
+
+  it("should handle very large numbers", () => {
+    expect(formatPrice(1234567)).toBe("1,234,567円");
+  });
+
+  it("should handle small numbers without comma", () => {
+    expect(formatPrice(100)).toBe("100円");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("should escape ampersand", () => {
+    expect(escapeHtml("a&b")).toBe("a&amp;b");
+  });
+
+  it("should escape angle brackets", () => {
+    expect(escapeHtml("<script>alert('xss')</script>")).toBe(
+      "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;",
+    );
+  });
+
+  it("should escape double quotes", () => {
+    expect(escapeHtml('a"b')).toBe("a&quot;b");
+  });
+
+  it("should escape single quotes", () => {
+    expect(escapeHtml("a'b")).toBe("a&#39;b");
+  });
+
+  it("should return plain text unchanged", () => {
+    expect(escapeHtml("TypeScript入門")).toBe("TypeScript入門");
+  });
+});
+
+describe("formatBookInfoHtml", () => {
+  it("should include book title", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("TypeScript入門");
+  });
+
+  it("should include author", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("鈴木僚太");
+  });
+
+  it("should include publisher", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("技術評論社");
+  });
+
+  it("should include ISBN", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("9784297138189");
+  });
+
+  it("should include formatted price", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("3,278円");
+  });
+
+  it("should include publication date", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("2022-04-22");
+  });
+
+  it("should include page count", () => {
+    const html = formatBookInfoHtml(sampleBookData);
+    expect(html).toContain("424");
+  });
+
+  it("should escape HTML in book fields to prevent XSS", () => {
+    const malicious: BookData = {
+      isbn: "1234567890",
+      title: '<script>alert("xss")</script>',
+      author: "a&b<c>",
+      publisher: "O'Reilly",
+      price: 0,
+      publicationDate: "",
+      pageCount: 0,
+      sourceUrl: "https://example.com",
+    };
+    const html = formatBookInfoHtml(malicious);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("a&amp;b&lt;c&gt;");
+    expect(html).toContain("O&#39;Reilly");
+  });
+
+  it("should handle empty optional fields gracefully", () => {
+    const minimal: BookData = {
+      isbn: "1234567890",
+      title: "Test",
+      author: "",
+      publisher: "",
+      price: 0,
+      publicationDate: "",
+      pageCount: 0,
+      sourceUrl: "https://example.com",
+    };
+    const html = formatBookInfoHtml(minimal);
+    expect(html).toContain("Test");
+    expect(html).toContain("1234567890");
+  });
+});

--- a/packages/extension/tests/unit/popup.test.ts
+++ b/packages/extension/tests/unit/popup.test.ts
@@ -1,0 +1,401 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type { BookData, RegistrationResponse } from "@techbook-ledger/shared";
+
+// Mock chrome API
+const chromeMock = {
+  tabs: {
+    query: vi.fn(),
+    sendMessage: vi.fn(),
+  },
+  runtime: {
+    sendMessage: vi.fn(),
+    lastError: null as chrome.runtime.LastError | null,
+  },
+  storage: {
+    sync: {
+      get: vi.fn(
+        (
+          keys: string | string[] | Record<string, unknown> | null,
+        ): Promise<Record<string, unknown>> => {
+          if (keys === null) return Promise.resolve({});
+          if (typeof keys === "object" && !Array.isArray(keys)) {
+            return Promise.resolve({ ...keys });
+          }
+          return Promise.resolve({});
+        },
+      ),
+      set: vi.fn((): Promise<void> => Promise.resolve()),
+    },
+  },
+};
+
+vi.stubGlobal("chrome", chromeMock);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// Import after mocking chrome
+const { initPopup } = await import("../../src/popup/popup.js");
+
+const sampleBookData: BookData = {
+  isbn: "9784297138189",
+  title: "TypeScript入門",
+  author: "鈴木僚太",
+  publisher: "技術評論社",
+  price: 3278,
+  publicationDate: "2022-04-22",
+  pageCount: 424,
+  sourceUrl: "https://gihyo.jp/book/2022/978-4-297-13818-9",
+};
+
+function setupPopupDom(): void {
+  document.body.innerHTML = `
+    <div id="status" class="status"></div>
+    <div id="book-info"></div>
+    <button id="register-btn" disabled>登録</button>
+    <div id="message"></div>
+  `;
+}
+
+describe("Popup UI: initPopup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupPopupDom();
+  });
+
+  describe("Initial state", () => {
+    it("should show inactive state when no book data found", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(null);
+      await initPopup({ getBookData: mockGetBookData });
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("inactive")).toBe(true);
+      expect(status.textContent).toContain("このページは対応していません");
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it("should show ready state with book info when book data found", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      await initPopup({ getBookData: mockGetBookData });
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("ready")).toBe(true);
+
+      const bookInfo = document.getElementById("book-info") as HTMLDivElement;
+      expect(bookInfo.innerHTML).toContain("TypeScript入門");
+      expect(bookInfo.innerHTML).toContain("鈴木僚太");
+    });
+
+    it("should enable register button in ready state", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      await initPopup({ getBookData: mockGetBookData });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it("should display all book fields in book-info area", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      await initPopup({ getBookData: mockGetBookData });
+
+      const bookInfo = document.getElementById("book-info") as HTMLDivElement;
+      expect(bookInfo.innerHTML).toContain("TypeScript入門");
+      expect(bookInfo.innerHTML).toContain("鈴木僚太");
+      expect(bookInfo.innerHTML).toContain("技術評論社");
+      expect(bookInfo.innerHTML).toContain("9784297138189");
+      expect(bookInfo.innerHTML).toContain("3,278円");
+      expect(bookInfo.innerHTML).toContain("2022-04-22");
+      expect(bookInfo.innerHTML).toContain("424");
+    });
+  });
+
+  describe("Registration flow", () => {
+    it("should show loading state when register button clicked", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const neverResolve = new Promise<RegistrationResponse>(() => {});
+      const mockRegisterBook = vi.fn().mockReturnValue(neverResolve);
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      // Let microtask queue process
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("loading")).toBe(true);
+    });
+
+    it("should disable button during loading", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const neverResolve = new Promise<RegistrationResponse>(() => {});
+      const mockRegisterBook = vi.fn().mockReturnValue(neverResolve);
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(btn.disabled).toBe(true);
+    });
+
+    it("should call registerBook with bookData", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: true,
+        message: "書籍を登録しました",
+      } satisfies RegistrationResponse);
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockRegisterBook).toHaveBeenCalledWith(sampleBookData);
+    });
+
+    it("should show success state after successful registration", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: true,
+        message: "書籍を登録しました",
+        notionUrl: "https://notion.so/page-id",
+      } satisfies RegistrationResponse);
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("success")).toBe(true);
+
+      const message = document.getElementById("message") as HTMLDivElement;
+      expect(message.textContent).toContain("書籍を登録しました");
+      expect(message.classList.contains("success")).toBe(true);
+    });
+
+    it("should show duplicate message for duplicate registration", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: false,
+        message: "この書籍は既に登録されています",
+        isDuplicate: true,
+        notionUrl: "https://notion.so/existing",
+      } satisfies RegistrationResponse);
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("success")).toBe(true);
+
+      const message = document.getElementById("message") as HTMLDivElement;
+      expect(message.textContent).toContain("この書籍は既に登録されています");
+    });
+
+    it("should show error state on registration failure", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: false,
+        message: "サーバーに接続できません",
+      } satisfies RegistrationResponse);
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("error")).toBe(true);
+
+      const message = document.getElementById("message") as HTMLDivElement;
+      expect(message.textContent).toContain("サーバーに接続できません");
+      expect(message.classList.contains("error")).toBe(true);
+    });
+  });
+
+  describe("Reset after result", () => {
+    it("should schedule reset with 3000ms delay", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: true,
+        message: "書籍を登録しました",
+      } satisfies RegistrationResponse);
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockScheduleReset).toHaveBeenCalledWith(
+        expect.any(Function),
+        3000,
+      );
+    });
+
+    it("should reset to ready state when reset fires", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: true,
+        message: "書籍を登録しました",
+      } satisfies RegistrationResponse);
+      let resetCallback: (() => void) | undefined;
+      const mockScheduleReset = vi.fn(
+        (cb: () => void) => {
+          resetCallback = cb;
+        },
+      );
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Trigger the reset callback
+      resetCallback!();
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("ready")).toBe(true);
+    });
+
+    it("should re-enable register button after reset", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi.fn().mockResolvedValue({
+        success: true,
+        message: "書籍を登録しました",
+      } satisfies RegistrationResponse);
+      let resetCallback: (() => void) | undefined;
+      const mockScheduleReset = vi.fn(
+        (cb: () => void) => {
+          resetCallback = cb;
+        },
+      );
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Button should be disabled after registration
+      expect(btn.disabled).toBe(true);
+
+      // Trigger reset
+      resetCallback!();
+
+      // Button should be re-enabled
+      expect(btn.disabled).toBe(false);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should return early when required DOM elements are missing", async () => {
+      document.body.innerHTML = "<div>no popup here</div>";
+      const mockGetBookData = vi.fn();
+
+      await initPopup({ getBookData: mockGetBookData });
+
+      expect(mockGetBookData).not.toHaveBeenCalled();
+    });
+
+    it("should handle getBookData rejection gracefully", async () => {
+      const mockGetBookData = vi
+        .fn()
+        .mockRejectedValue(new Error("tab not found"));
+
+      await initPopup({ getBookData: mockGetBookData });
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("error")).toBe(true);
+      expect(status.textContent).toBeTruthy();
+    });
+
+    it("should handle registerBook rejection gracefully", async () => {
+      const mockGetBookData = vi.fn().mockResolvedValue(sampleBookData);
+      const mockRegisterBook = vi
+        .fn()
+        .mockRejectedValue(new Error("network error"));
+      const mockScheduleReset = vi.fn();
+
+      await initPopup({
+        getBookData: mockGetBookData,
+        registerBook: mockRegisterBook,
+        scheduleReset: mockScheduleReset,
+      });
+
+      const btn = document.getElementById("register-btn") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const status = document.getElementById("status") as HTMLDivElement;
+      expect(status.classList.contains("error")).toBe(true);
+
+      const message = document.getElementById("message") as HTMLDivElement;
+      expect(message.textContent).toBeTruthy();
+      expect(message.classList.contains("error")).toBe(true);
+    });
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -251,6 +251,41 @@
 
 ---
 
+# Task 10: Popup UIの実装
+
+## Plan
+- [x] 10.1 Popup HTML/CSS の作成
+  - status div にクラス追加、360px 幅ポップアップスタイリング
+  - settings.css と統一デザイン (色、フォント、ボーダー半径)
+  - 5 状態のステータス表示 (inactive/ready/loading/success/error)
+  - Requirements: 9.1, 9.2, 9.3, 9.5
+
+- [x] 10.2 Popup ロジックの実装
+  - popup-state.ts: 純粋関数 (状態導出、formatPrice、formatBookInfoHtml)
+  - messages.ts: メッセージプロトコル型定義 (GET_BOOK_DATA, REGISTER_BOOK)
+  - popup.ts: initPopup(deps?) + renderState + autoInit
+  - 依存注入パターンで getBookData/registerBook/scheduleReset を差し替え可能
+  - 3秒間の結果表示とリセット (scheduleReset 注入でテスト容易)
+  - Requirements: 3.1, 3.6, 3.7, 9.1, 9.3, 9.4, 9.5
+
+- [x] 10.3 Popup UI のユニットテスト
+  - popup-state.test.ts: 23 テスト (純粋関数のテスト)
+  - popup.test.ts: 16 テスト (DOM 統合テスト)
+  - TDD: RED -> GREEN -> REFACTOR サイクル
+  - Requirements: 9.1, 9.2, 9.3, 9.4
+
+## Review
+
+| チェック | 結果 |
+|---------|------|
+| lint | 0 errors, 0 warnings |
+| type-check | Success (shared, server, extension) |
+| テスト | 276 passed (extension 160, server 116) |
+| カバレッジ | 89% stmts / 92.51% branch / 92.1% funcs / 89% lines |
+| ビルド | Build successful (shared, server, extension) |
+
+---
+
 # Task 12: Settings Pageの実装
 
 ## Plan


### PR DESCRIPTION
## 概要
Chrome 拡張機能の Popup UI を実装。書籍販売サイト上の JSON-LD から抽出した書籍情報を表示し、ワンクリックで Notion に登録するインターフェース。

## 背景・目的
Task 10 として、Popup UI の HTML/CSS/ロジック/テストを TDD で実装する。
Closes #20

## 変更内容
- `popup-state.ts` (新規): 純粋関数 - 状態導出、formatPrice、formatBookInfoHtml
- `messages.ts` (新規): メッセージプロトコル型定義 (GET_BOOK_DATA, REGISTER_BOOK)
- `popup.ts` (スタブ置換): initPopup + renderState + autoInit (依存注入パターン)
- `popup.css` (スタブ置換): 5 状態のステータス表示、settings.css と統一デザイン
- `index.html`: status div にクラス追加
- `popup-state.test.ts` (新規): 23 テスト (純粋関数)
- `popup.test.ts` (新規): 16 テスト (DOM 統合)
- `CLAUDE.md`: 単一テストファイル実行コマンドを `test:file` スクリプトに修正

## スコープ外（やっていないこと）
- Service Worker (Task 11) の実装 - メッセージプロトコルの型定義のみ
- Content Script エントリ (Task 9) の実装 - 同上
- E2E テスト - 統合テスト (Task 15) で実施予定

## 動作確認方法
1. `pnpm install`
2. `pnpm test` - 全 276 テスト通過
3. `pnpm lint` - エラー 0
4. `pnpm typecheck` - 全パッケージ通過
5. `pnpm build` - ビルド成功

## チェックリスト
- [x] セルフレビュー済み
- [x] テストを追加・更新した (39 テスト新規追加)
- [x] 既存テストがすべて通る (276 passed)
- [x] カバレッジ 80%+ (89% stmts, 92.51% branch, 92.1% funcs, 89% lines)

## レビュアーへのメモ
- 依存注入パターンにより、Service Worker/Content Script が未実装でも Popup ロジックを完全にテスト可能
- `scheduleReset` の注入で `vi.useFakeTimers()` を回避 (Task 2 の教訓)
- `messages.ts` は Task 11 (Service Worker) が実装する際のメッセージ契約として機能する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed extension popup UI: displays full book details, formatted price (¥), register button, animated loading spinner, and contextual status (inactive/ready/loading/success/error).
  * Registration flow with real-time feedback and automatic reset after completion.

* **Style**
  * Added comprehensive popup styles and spinner animation.

* **Tests**
  * Added extensive unit tests covering popup state, UI rendering, registration flows, and edge cases.

* **Documentation**
  * Simplified test documentation and streamlined single-test command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->