### PR TITLE
feat(extension): Service Worker の実装 (Task 11) #23

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -192,15 +192,15 @@
     - 登録フロー全体のテスト
     - _Requirements: 9.1, 9.2, 9.3, 9.4_
 
-- [ ] 11. Service Workerの実装
-  - [ ] 11.1 Service Workerロジックの実装
+- [x] 11. Service Workerの実装
+  - [x] 11.1 Service Workerロジックの実装
     - registerBook()関数: Local_Serverへのリクエスト送信
     - 設定読込（Extension Storage）
     - エラーハンドリング（サーバー未起動、ネットワークエラー）
     - Popup UIへのレスポンス返却
     - _Requirements: 3.1, 4.2, 7.2_
-  
-  - [ ] 11.2 Service Workerのユニットテスト
+
+  - [x] 11.2 Service Workerのユニットテスト
     - サーバー接続エラー処理のテスト
     - レスポンス解析のテスト
     - _Requirements: 7.2_

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -1,1 +1,123 @@
-// Service Worker - to be implemented in Task 11
+import type {
+  BookData,
+  RegistrationResponse,
+  ExtensionConfig,
+} from "@techbook-ledger/shared";
+import type { RegisterBookMessage } from "../popup/messages.js";
+import { loadConfig as loadConfigFromStorage } from "../storage/config.js";
+
+export interface ServiceWorkerDeps {
+  readonly loadConfig?: () => Promise<ExtensionConfig>;
+  readonly fetchFn?: typeof fetch;
+}
+
+export function parseRegistrationResponse(data: unknown): RegistrationResponse {
+  if (typeof data !== "object" || data === null) {
+    return {
+      success: false,
+      message: "サーバーから不正なレスポンスを受信しました",
+    };
+  }
+
+  const obj = data as Record<string, unknown>;
+  const success = typeof obj.success === "boolean" ? obj.success : false;
+  const message =
+    typeof obj.message === "string" ? obj.message : "不明なエラーが発生しました";
+
+  return {
+    success,
+    message,
+    ...(typeof obj.notionUrl === "string" ? { notionUrl: obj.notionUrl } : {}),
+    ...(typeof obj.isDuplicate === "boolean"
+      ? { isDuplicate: obj.isDuplicate }
+      : {}),
+  };
+}
+
+export function isRegisterBookMessage(
+  message: unknown,
+): message is RegisterBookMessage {
+  if (typeof message !== "object" || message === null) {
+    return false;
+  }
+
+  const obj = message as Record<string, unknown>;
+  return (
+    obj.type === "REGISTER_BOOK" &&
+    typeof obj.bookData === "object" &&
+    obj.bookData !== null
+  );
+}
+
+export async function registerBook(
+  bookData: BookData,
+  deps?: ServiceWorkerDeps,
+): Promise<RegistrationResponse> {
+  let config: ExtensionConfig;
+  try {
+    config = await (deps?.loadConfig ?? loadConfigFromStorage)();
+  } catch (error) {
+    console.error("Failed to load extension config:", error);
+    return {
+      success: false,
+      message:
+        "拡張機能の設定を読み込めませんでした。設定ページを確認してください",
+    };
+  }
+  const fetchImpl = deps?.fetchFn ?? fetch;
+  const url = `${config.serverEndpoint}/api/books`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(bookData),
+    });
+  } catch (error) {
+    console.error("Failed to connect to local server:", error);
+    return {
+      success: false,
+      message:
+        "ローカルサーバーに接続できません。サーバーを起動してください",
+    };
+  }
+
+  try {
+    const data: unknown = await response.json();
+    return parseRegistrationResponse(data);
+  } catch (error) {
+    console.error("Failed to parse server response:", error);
+    return {
+      success: false,
+      message: `サーバーから予期しないレスポンスを受信しました (HTTP ${String(response.status)})`,
+    };
+  }
+}
+
+export function setupMessageListener(deps?: ServiceWorkerDeps): void {
+  chrome.runtime.onMessage.addListener(
+    (
+      message: unknown,
+      _sender: chrome.runtime.MessageSender,
+      sendResponse: (response: RegistrationResponse) => void,
+    ): boolean => {
+      if (isRegisterBookMessage(message)) {
+        registerBook(message.bookData, deps)
+          .then(sendResponse)
+          .catch((error: unknown) => {
+            console.error("Unexpected error in registerBook:", error);
+            sendResponse({
+              success: false,
+              message: "予期しないエラーが発生しました",
+            });
+          });
+        return true;
+      }
+      return false;
+    },
+  );
+}
+
+// Auto-initialize when loaded as service worker
+setupMessageListener();

--- a/packages/extension/tests/unit/service-worker.test.ts
+++ b/packages/extension/tests/unit/service-worker.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type {
+  BookData,
+  RegistrationResponse,
+  ExtensionConfig,
+} from "@techbook-ledger/shared";
+
+// Mock chrome API
+const chromeMock = {
+  runtime: {
+    onMessage: {
+      addListener: vi.fn(),
+    },
+  },
+  storage: {
+    sync: {
+      get: vi.fn(
+        (
+          keys: string | string[] | Record<string, unknown> | null,
+        ): Promise<Record<string, unknown>> => {
+          if (keys === null) return Promise.resolve({});
+          if (typeof keys === "object" && !Array.isArray(keys)) {
+            return Promise.resolve({ ...keys });
+          }
+          return Promise.resolve({});
+        },
+      ),
+      set: vi.fn((): Promise<void> => Promise.resolve()),
+    },
+  },
+};
+
+vi.stubGlobal("chrome", chromeMock);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// Import after mocking chrome
+const {
+  registerBook,
+  parseRegistrationResponse,
+  isRegisterBookMessage,
+  setupMessageListener,
+} = await import("../../src/background/service-worker.js");
+
+const sampleBookData: BookData = {
+  isbn: "9784297138189",
+  title: "TypeScript入門",
+  author: "鈴木僚太",
+  publisher: "技術評論社",
+  price: 3278,
+  publicationDate: "2022-04-22",
+  pageCount: 424,
+  sourceUrl: "https://gihyo.jp/book/2022/978-4-297-13818-9",
+};
+
+const defaultConfig: ExtensionConfig = {
+  serverEndpoint: "http://localhost:3000",
+  whitelist: ["amazon.co.jp", "gihyo.jp", "*.amazon.co.jp"],
+};
+
+function createMockResponse(
+  body: unknown,
+  status: number = 200,
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+function createMockLoadConfig(
+  config: ExtensionConfig = defaultConfig,
+): () => Promise<ExtensionConfig> {
+  return vi.fn().mockResolvedValue(config);
+}
+
+describe("Service Worker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("registerBook", () => {
+    it("should send POST request and return success response", async () => {
+      const serverResponse: RegistrationResponse = {
+        success: true,
+        message: "書籍を登録しました",
+        notionUrl: "https://notion.so/page-id",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(serverResponse, 201),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(serverResponse);
+    });
+
+    it("should send correct headers and body", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse({ success: true, message: "OK" }, 201),
+      );
+
+      await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3000/api/books",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(sampleBookData),
+        },
+      );
+    });
+
+    it("should use serverEndpoint from loaded config", async () => {
+      const customConfig: ExtensionConfig = {
+        serverEndpoint: "http://127.0.0.1:4000",
+        whitelist: [],
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse({ success: true, message: "OK" }, 201),
+      );
+
+      await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(customConfig),
+        fetchFn: mockFetch,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:4000/api/books",
+        expect.any(Object),
+      );
+    });
+
+    it("should return duplicate response from server", async () => {
+      const duplicateResponse: RegistrationResponse = {
+        success: false,
+        message: "この書籍は既に登録されています",
+        isDuplicate: true,
+        notionUrl: "https://notion.so/existing-page",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(duplicateResponse, 200),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(duplicateResponse);
+    });
+
+    it("should return validation error response from server (400)", async () => {
+      const errorResponse: RegistrationResponse = {
+        success: false,
+        message: "必須フィールドが欠けています: title",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(errorResponse, 400),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(errorResponse);
+    });
+
+    it("should return rate limit error response from server (429)", async () => {
+      const errorResponse: RegistrationResponse = {
+        success: false,
+        message: "Notion APIがビジー状態です。しばらく待ってから再試行してください",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(errorResponse, 429),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(errorResponse);
+    });
+
+    it("should return auth error response from server (500)", async () => {
+      const errorResponse: RegistrationResponse = {
+        success: false,
+        message: "Notion認証に失敗しました。環境変数を確認してください",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(errorResponse, 500),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(errorResponse);
+    });
+
+    it("should return connection error response from server (503)", async () => {
+      const errorResponse: RegistrationResponse = {
+        success: false,
+        message: "Notionに接続できません。ネットワーク接続を確認してください",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(errorResponse, 503),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result).toEqual(errorResponse);
+    });
+
+    it("should handle network error when server is not running", async () => {
+      const mockFetch = vi.fn().mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("サーバー");
+    });
+
+    it("should handle non-JSON response", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError("Unexpected token")),
+      } as Response;
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("予期しないレスポンス");
+      expect(result.message).toContain("200");
+    });
+
+    it("should return config error when loadConfig fails", async () => {
+      const mockLoadConfig = vi
+        .fn()
+        .mockRejectedValue(new Error("storage read failed"));
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: mockLoadConfig,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("設定");
+    });
+
+    it("should handle non-TypeError exceptions during fetch", async () => {
+      const mockFetch = vi.fn().mockRejectedValue(
+        new Error("AbortError"),
+      );
+
+      const result = await registerBook(sampleBookData, {
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  describe("parseRegistrationResponse", () => {
+    it("should parse valid success response", () => {
+      const data = {
+        success: true,
+        message: "書籍を登録しました",
+        notionUrl: "https://notion.so/page-id",
+      };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result).toEqual({
+        success: true,
+        message: "書籍を登録しました",
+        notionUrl: "https://notion.so/page-id",
+      });
+    });
+
+    it("should parse duplicate response with isDuplicate field", () => {
+      const data = {
+        success: false,
+        message: "この書籍は既に登録されています",
+        isDuplicate: true,
+        notionUrl: "https://notion.so/existing",
+      };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result).toEqual({
+        success: false,
+        message: "この書籍は既に登録されています",
+        isDuplicate: true,
+        notionUrl: "https://notion.so/existing",
+      });
+    });
+
+    it("should parse minimal response without optional fields", () => {
+      const data = {
+        success: false,
+        message: "エラーが発生しました",
+      };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result).toEqual({
+        success: false,
+        message: "エラーが発生しました",
+      });
+      expect(result.notionUrl).toBeUndefined();
+      expect(result.isDuplicate).toBeUndefined();
+    });
+
+    it("should return defaults for non-object data", () => {
+      const result = parseRegistrationResponse("not an object");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBeTruthy();
+    });
+
+    it("should return defaults for null data", () => {
+      const result = parseRegistrationResponse(null);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBeTruthy();
+    });
+
+    it("should handle missing success field", () => {
+      const data = { message: "some message" };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("some message");
+    });
+
+    it("should handle missing message field", () => {
+      const data = { success: true };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result.success).toBe(true);
+      expect(typeof result.message).toBe("string");
+      expect(result.message.length).toBeGreaterThan(0);
+    });
+
+    it("should ignore non-string notionUrl", () => {
+      const data = {
+        success: true,
+        message: "OK",
+        notionUrl: 123,
+      };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result.notionUrl).toBeUndefined();
+    });
+
+    it("should ignore non-boolean isDuplicate", () => {
+      const data = {
+        success: false,
+        message: "error",
+        isDuplicate: "yes",
+      };
+
+      const result = parseRegistrationResponse(data);
+
+      expect(result.isDuplicate).toBeUndefined();
+    });
+  });
+
+  describe("isRegisterBookMessage", () => {
+    it("should return true for valid REGISTER_BOOK message", () => {
+      const message = {
+        type: "REGISTER_BOOK",
+        bookData: sampleBookData,
+      };
+
+      expect(isRegisterBookMessage(message)).toBe(true);
+    });
+
+    it("should return false for null", () => {
+      expect(isRegisterBookMessage(null)).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isRegisterBookMessage(undefined)).toBe(false);
+    });
+
+    it("should return false for wrong message type", () => {
+      const message = {
+        type: "GET_BOOK_DATA",
+        bookData: sampleBookData,
+      };
+
+      expect(isRegisterBookMessage(message)).toBe(false);
+    });
+
+    it("should return false for missing bookData", () => {
+      const message = { type: "REGISTER_BOOK" };
+
+      expect(isRegisterBookMessage(message)).toBe(false);
+    });
+
+    it("should return false for null bookData", () => {
+      const message = { type: "REGISTER_BOOK", bookData: null };
+
+      expect(isRegisterBookMessage(message)).toBe(false);
+    });
+
+    it("should return false for non-object bookData", () => {
+      const message = { type: "REGISTER_BOOK", bookData: "string" };
+
+      expect(isRegisterBookMessage(message)).toBe(false);
+    });
+
+    it("should return false for primitive values", () => {
+      expect(isRegisterBookMessage(42)).toBe(false);
+      expect(isRegisterBookMessage("string")).toBe(false);
+      expect(isRegisterBookMessage(true)).toBe(false);
+    });
+  });
+
+  describe("setupMessageListener", () => {
+    it("should register a message listener", () => {
+      setupMessageListener();
+
+      expect(chromeMock.runtime.onMessage.addListener).toHaveBeenCalledTimes(1);
+      expect(chromeMock.runtime.onMessage.addListener).toHaveBeenCalledWith(
+        expect.any(Function),
+      );
+    });
+
+    it("should call registerBook for REGISTER_BOOK message", async () => {
+      const serverResponse: RegistrationResponse = {
+        success: true,
+        message: "書籍を登録しました",
+      };
+      const mockFetch = vi.fn().mockResolvedValue(
+        createMockResponse(serverResponse, 201),
+      );
+
+      setupMessageListener({
+        loadConfig: createMockLoadConfig(),
+        fetchFn: mockFetch,
+      });
+
+      const listener = chromeMock.runtime.onMessage.addListener.mock
+        .calls[0][0] as (
+        message: unknown,
+        sender: chrome.runtime.MessageSender,
+        sendResponse: (response: RegistrationResponse) => void,
+      ) => boolean;
+
+      const sendResponse = vi.fn();
+      const result = listener(
+        { type: "REGISTER_BOOK", bookData: sampleBookData },
+        {} as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      // Should return true to keep channel open for async response
+      expect(result).toBe(true);
+
+      // Wait for async processing
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sendResponse).toHaveBeenCalledWith(serverResponse);
+    });
+
+    it("should return false for non-REGISTER_BOOK messages", () => {
+      setupMessageListener();
+
+      const listener = chromeMock.runtime.onMessage.addListener.mock
+        .calls[0][0] as (
+        message: unknown,
+        sender: chrome.runtime.MessageSender,
+        sendResponse: (response: unknown) => void,
+      ) => boolean;
+
+      const sendResponse = vi.fn();
+      const result = listener(
+        { type: "GET_BOOK_DATA" },
+        {} as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      expect(result).toBe(false);
+      expect(sendResponse).not.toHaveBeenCalled();
+    });
+
+    it("should send error response when loadConfig fails", async () => {
+      const mockLoadConfig = vi
+        .fn()
+        .mockRejectedValue(new Error("storage read failed"));
+
+      setupMessageListener({
+        loadConfig: mockLoadConfig,
+      });
+
+      const listener = chromeMock.runtime.onMessage.addListener.mock
+        .calls[0][0] as (
+        message: unknown,
+        sender: chrome.runtime.MessageSender,
+        sendResponse: (response: RegistrationResponse) => void,
+      ) => boolean;
+
+      const sendResponse = vi.fn();
+      listener(
+        { type: "REGISTER_BOOK", bookData: sampleBookData },
+        {} as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sendResponse).toHaveBeenCalledTimes(1);
+      const response = sendResponse.mock.calls[0][0] as RegistrationResponse;
+      expect(response.success).toBe(false);
+      expect(response.message).toContain("設定");
+    });
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -315,3 +315,31 @@
 | テスト | 170 passed (extension 54, server 116) |
 | カバレッジ | settings.ts 94.59%/84.37%/100%/94.59%, 全体 96.22% |
 | ビルド | Build successful (shared, server, extension) |
+
+---
+
+# Task 11: Service Workerの実装
+
+## Plan
+- [x] 11.2 Service Worker ユニットテスト作成 (tests/unit/service-worker.test.ts) - RED
+  - registerBook(): 成功/重複/400/429/500/503/ネットワークエラー/非JSONレスポンス
+  - parseRegistrationResponse(): 有効レスポンス/オプショナルフィールド/不正データ
+  - isRegisterBookMessage(): 有効/無効メッセージ判定
+  - setupMessageListener(): リスナー登録/REGISTER_BOOK処理/無関係メッセージ無視/エラー処理
+- [x] 11.1 Service Worker ロジックの実装 (src/background/service-worker.ts) - GREEN
+  - registerBook(): Extension StorageからserverEndpoint取得、fetch POST、レスポンス解析
+  - parseRegistrationResponse(): 防御的パース (unknown -> RegistrationResponse)
+  - isRegisterBookMessage(): 型ガード
+  - setupMessageListener(): chrome.runtime.onMessage リスナー登録
+  - DI パターン (ServiceWorkerDeps) でテスタビリティ確保
+- [x] 品質確認 (lint, typecheck, test, coverage, build)
+
+## Review
+
+| チェック | 結果 |
+|---------|------|
+| lint | 0 errors, 0 warnings |
+| type-check | Success (shared, server, extension) |
+| テスト | 198 passed (extension 82 (32 new), server 116) |
+| カバレッジ | service-worker.ts 95.4%/93.33%/100%/95.4%, 全体 90.16% |
+| ビルド | Build successful (shared, server, extension) |


### PR DESCRIPTION
## 概要
Chrome 拡張機能の Service Worker を TDD で実装。Popup UI からの `REGISTER_BOOK` メッセージを受け取り、ローカルサーバー (`POST /api/books`) にリクエストを中継して結果を返す。

## 背景・目的
Task 10 で Popup UI が完成し、`chrome.runtime.sendMessage` で Service Worker にメッセージを送信する仕組みが整った。Service Worker がスタブのままだったため、ローカルサーバーとの通信を担う本体を実装する。

Closes #23

## 変更内容
- `src/background/service-worker.ts`: Service Worker 本体の実装
  - `registerBook()`: Extension Storage から設定読込、fetch POST、レスポンス解析
  - `parseRegistrationResponse()`: 防御的パース (unknown -> RegistrationResponse)
  - `isRegisterBookMessage()`: 型ガード
  - `setupMessageListener()`: chrome.runtime.onMessage リスナー登録
  - DI パターン (ServiceWorkerDeps) でテスタビリティ確保
- `tests/unit/service-worker.test.ts`: 32 ユニットテスト追加
  - 成功/重複/400/429/500/503/ネットワークエラー/非JSONレスポンス
  - レスポンス解析の防御的パース検証
  - メッセージリスナーの動作検証
- `docs/tasks.md`: Task 11 の完了チェックマーク更新
- `tasks/todo.md`: レビューセクション追加

## スコープ外（やっていないこと）
- Content Script の実装 (Task 9 の残り)
- エラーハンドリングの統合 (Task 13)
- E2E テスト (Task 15)

## 動作確認方法
1. `pnpm run test:f extension` - 198 テスト全通過
2. `pnpm run typecheck:f extension` - 型チェック通過
3. `pnpm lint` - lint エラーなし
4. `pnpm build` - ビルド成功
5. `pnpm run test:coverage:f extension` - カバレッジ 90%+ (service-worker.ts: 95.4%)

## チェックリスト
- [x] セルフレビュー済み
- [x] テストを追加・更新した
- [x] 既存テストがすべて通る
- [x] ドキュメントを更新した（tasks.md）
- [ ] Breaking Changeがある場合は明記した (該当なし)

## レビュアーへのメモ
- popup.ts と同じ DI パターン (`ServiceWorkerDeps`) を採用。テスト時に `loadConfig` と `fetchFn` をモック注入可能
- `parseRegistrationResponse()` は防御的に unknown を解析。不正なデータに対してもクラッシュせずデフォルトエラーを返す
- サーバーは既に適切な RegistrationResponse JSON を返すため、Service Worker はネットワークレベルのエラーと非 JSON レスポンスのみ独自にハンドリング

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Task list updated: Service Worker tasks marked complete; a duplicate Task 11 entry was also added.

* **New Features**
  * Service Worker implementation completed: message-based book registration, response parsing, duplicate detection, and robust error handling with configurable server endpoint.

* **Tests**
  * Comprehensive unit tests added covering successful registration, various server/network errors, response validation, and message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->