### PR TITLE
fix(ci): remove --max-turns limit from Claude Code Action

### DIFF
--- a/.github/workflows/fix-review.yml
+++ b/.github/workflows/fix-review.yml
@@ -58,7 +58,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "coderabbitai[bot]"
-          claude_args: "--max-turns 5"
           prompt: |
             This PR has received review feedback from Code Rabbit.
             Fix the issues pointed out in the review comments.


### PR DESCRIPTION
## Summary

Claude Code Action の `--max-turns 5` 制限を削除。
ターン上限により修正が完了する前に `error_max_turns` で失敗していた。

## Changes

- `claude_args: "--max-turns 5"` を削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for code review automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->