### PR TITLE
fix(shared): fix typecheck errors in __test-sample.ts

### DIFF
--- a/packages/shared/src/utils/__test-sample.ts
+++ b/packages/shared/src/utils/__test-sample.ts
@@ -1,0 +1,47 @@
+export function divide(a: number, b: number) {
+  if (b === 0) {
+    throw new Error("Division by zero is not allowed");
+  }
+  return a / b;
+}
+
+export function parseAge(input: string | number): number {
+  const str = String(input).trim();
+  if (!/^\d+$/.test(str)) {
+    throw new RangeError("Invalid age");
+  }
+  const value = Number.parseInt(str, 10);
+  if (Number.isNaN(value) || value < 0) {
+    throw new RangeError("Invalid age");
+  }
+  return value;
+}
+
+export function getItems<T>(data: T[]): T[] {
+  return [...data];
+}
+
+export function formatName(first: string, last: string) {
+  return first + " " + last;
+}
+
+export function processData<T>(data: readonly (T | null | undefined)[]): T[] {
+  const results: T[] = [];
+  for (const item of data) {
+    if (item != null) {
+      results.push(item);
+    }
+  }
+  return results;
+}
+
+export function toUpperCase(value: string | undefined) {
+  if (value === undefined) {
+    throw new TypeError("value must be defined");
+  }
+  return value.toUpperCase();
+}
+
+export function fetchData(url: string): string {
+  return `fetching: ${url}`;
+}

--- a/packages/shared/tests/unit/__test-sample.test.ts
+++ b/packages/shared/tests/unit/__test-sample.test.ts
@@ -1,0 +1,113 @@
+import { divide, parseAge, getItems, formatName, processData, toUpperCase, fetchData } from "../../src/utils/__test-sample.js";
+
+describe("divide", () => {
+  it("returns the quotient of two numbers", () => {
+    expect(divide(10, 2)).toBe(5);
+    expect(divide(9, 3)).toBe(3);
+    expect(divide(7, 2)).toBe(3.5);
+  });
+
+  it("throws when dividing by zero", () => {
+    expect(() => divide(1, 0)).toThrowError("Division by zero is not allowed");
+    expect(() => divide(0, 0)).toThrowError("Division by zero is not allowed");
+  });
+});
+
+describe("parseAge", () => {
+  it("parses a valid numeric string", () => {
+    expect(parseAge("25")).toBe(25);
+    expect(parseAge("0")).toBe(0);
+    expect(parseAge("100")).toBe(100);
+  });
+
+  it("parses a number input", () => {
+    expect(parseAge(30)).toBe(30);
+    expect(parseAge(0)).toBe(0);
+  });
+
+  it("throws RangeError for negative values", () => {
+    expect(() => parseAge(-1)).toThrowError(RangeError);
+    expect(() => parseAge("-5")).toThrowError(RangeError);
+  });
+
+  it("throws RangeError for non-numeric strings", () => {
+    expect(() => parseAge("abc")).toThrowError(RangeError);
+    expect(() => parseAge("")).toThrowError(RangeError);
+  });
+
+  it("throws RangeError for partially numeric strings", () => {
+    expect(() => parseAge("12abc")).toThrowError(RangeError);
+    expect(() => parseAge("42years")).toThrowError(RangeError);
+    expect(() => parseAge("12.3")).toThrowError(RangeError);
+  });
+});
+
+describe("getItems", () => {
+  it("returns a copy of the input array", () => {
+    const input = [1, 2, 3];
+    const result = getItems(input);
+    expect(result).toEqual([1, 2, 3]);
+    expect(result).not.toBe(input);
+  });
+
+  it("works with string arrays", () => {
+    expect(getItems(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(getItems([])).toEqual([]);
+  });
+
+  it("works with object arrays", () => {
+    const objs = [{ id: 1 }, { id: 2 }];
+    expect(getItems(objs)).toEqual(objs);
+  });
+});
+
+describe("formatName", () => {
+  it("concatenates first and last name with a space", () => {
+    expect(formatName("John", "Doe")).toBe("John Doe");
+    expect(formatName("Alice", "Smith")).toBe("Alice Smith");
+  });
+
+  it("handles empty strings", () => {
+    expect(formatName("", "Doe")).toBe(" Doe");
+    expect(formatName("John", "")).toBe("John ");
+    expect(formatName("", "")).toBe(" ");
+  });
+});
+
+describe("processData", () => {
+  it("filters out null and undefined values", () => {
+    expect(processData([1, null, 2, undefined, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("preserves non-null values", () => {
+    expect(processData([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(processData([])).toEqual([]);
+  });
+});
+
+describe("toUpperCase", () => {
+  it("converts string to uppercase", () => {
+    expect(toUpperCase("hello")).toBe("HELLO");
+    expect(toUpperCase("test")).toBe("TEST");
+  });
+
+  it("throws TypeError when value is undefined", () => {
+    expect(() => toUpperCase(undefined)).toThrowError(TypeError);
+  });
+});
+
+describe("fetchData", () => {
+  it("returns a string containing the URL", () => {
+    expect(fetchData("https://example.com")).toBe("fetching: https://example.com");
+  });
+
+  it("handles empty URL", () => {
+    expect(fetchData("")).toBe("fetching: ");
+  });
+});


### PR DESCRIPTION
## Summary
- `__test-sample.ts` の `fetchData` 関数が `fetch()`/`Response` を使用していたが、`tsconfig.base.json` の `lib: ["ES2022"]` に DOM が含まれないため型チェックエラーが発生していた
- `fetchData` を同期関数に変更し、テストも合わせて更新

## Changes
- `packages/shared/src/utils/__test-sample.ts`: `fetchData` を `fetch()` 依存から文字列返却のシンプルな関数に変更
- `packages/shared/tests/unit/__test-sample.test.ts`: `fetchData` テストを同期テストに変更（`globalThis.fetch` モック不要に）

## Test plan
- [x] `pnpm lint` - パス
- [x] `pnpm typecheck` - パス（全3パッケージ）
- [x] `pnpm test` - パス（shared: 71 tests, server: 140 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for shared utility functions across multiple scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->